### PR TITLE
fix(console): node-aware status for pods and models

### DIFF
--- a/ui/src/features/models/model-detail-page.tsx
+++ b/ui/src/features/models/model-detail-page.tsx
@@ -13,10 +13,13 @@ import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { LoadingState, ErrorState } from "@/components/common/states";
-import { claimHealth } from "@/lib/resource-health";
+import { claimHealth, nodeAwareHealth } from "@/lib/resource-health";
 import { ApiError, k8sDelete, k8sGet, modelChat, type ChatMessage } from "@/lib/api";
 import { openinfraPaths } from "@/lib/k8s-paths";
+import { useNodeHealth } from "@/hooks/use-node-health";
+import { usePodNodeIndex } from "@/hooks/use-pod-node-index";
 import { cn } from "@/lib/utils";
+import { AlertTriangle } from "lucide-react";
 import type { K8sObject, Model } from "@/types/k8s";
 
 function decode(v?: string): string {
@@ -128,6 +131,8 @@ export function ModelDetailPage() {
   const [showKey, setShowKey] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const navigate = useNavigate();
+  const { offlineNodes } = useNodeHealth();
+  const podIndex = usePodNodeIndex(namespace);
   const deleteMutation = useMutation({
     mutationFn: () => k8sDelete(openinfraPaths.model(namespace, name)),
     onSuccess: () => navigate({ to: "/models" }),
@@ -152,7 +157,8 @@ export function ModelDetailPage() {
   const data = secret?.data ?? {};
   const endpoint = decode(data["OPENAI_BASE_URL"]);
   const apiKey = decode(data["OPENAI_API_KEY"]);
-  const health = claimHealth(model);
+  const nodes = podIndex.nodesForApp(namespace, name);
+  const health = nodeAwareHealth(claimHealth(model), nodes, offlineNodes);
 
   return (
     <DetailShell
@@ -187,6 +193,35 @@ export function ModelDetailPage() {
               <DetailRow label="Model">{model.spec?.model ?? "—"}</DetailRow>
               <DetailRow label="GPUs">{model.spec?.gpu ?? 1}×</DetailRow>
               <DetailRow label="Namespace">{namespace}</DetailRow>
+              <DetailRow label="Node">
+                {nodes.length === 0 ? (
+                  <span className="text-muted-foreground">
+                    No running pod (scaled to zero or unscheduled)
+                  </span>
+                ) : (
+                  <span className="flex flex-wrap items-center gap-2">
+                    {nodes.map((n) => {
+                      const offline = offlineNodes.has(n);
+                      return (
+                        <span
+                          key={n}
+                          className={cn(
+                            "flex items-center gap-1",
+                            offline && "font-medium text-destructive",
+                          )}
+                          title={offline ? "Node is NotReady" : undefined}
+                        >
+                          {offline ? (
+                            <AlertTriangle className="size-3.5" />
+                          ) : null}
+                          <code className="text-xs">{n}</code>
+                          {offline ? " (offline)" : ""}
+                        </span>
+                      );
+                    })}
+                  </span>
+                )}
+              </DetailRow>
               <DetailRow label="Endpoint (OpenAI-compatible)">
                 <span className="flex items-center gap-1">
                   <code className="text-xs">{endpoint || "—"}</code>

--- a/ui/src/features/models/models-page.tsx
+++ b/ui/src/features/models/models-page.tsx
@@ -6,8 +6,10 @@ import { StatusBadge } from "@/components/common/status-badge";
 import { ResourceTablePage } from "@/components/common/resource-table-page";
 import { NewResourceDialog } from "@/components/common/new-resource-dialog";
 import { Button } from "@/components/ui/button";
-import { claimHealth } from "@/lib/resource-health";
+import { claimHealth, nodeAwareHealth } from "@/lib/resource-health";
 import { useK8sWatch } from "@/hooks/use-k8s-watch";
+import { useNodeHealth } from "@/hooks/use-node-health";
+import { usePodNodeIndex } from "@/hooks/use-pod-node-index";
 import { useNamespace } from "@/lib/namespace-context";
 import { corePaths, openinfraPaths } from "@/lib/k8s-paths";
 import { age } from "@/lib/format";
@@ -17,6 +19,8 @@ export function ModelsPage() {
   const navigate = useNavigate();
   const { scoped } = useNamespace();
   const [newOpen, setNewOpen] = useState(false);
+  const { offlineNodes } = useNodeHealth();
+  const podIndex = usePodNodeIndex(scoped);
   const nsWatch = useK8sWatch<K8sObject>(corePaths.namespaces());
   const namespaces = nsWatch.items
     .map((n) => n.metadata.name)
@@ -67,9 +71,19 @@ export function ModelsPage() {
       {
         id: "status",
         header: "Status",
-        accessorFn: (m) => claimHealth(m).label,
+        accessorFn: (m) =>
+          nodeAwareHealth(
+            claimHealth(m),
+            podIndex.nodesForApp(m.metadata.namespace, m.metadata.name),
+            offlineNodes,
+          ).label,
         cell: ({ row }) => {
-          const h = claimHealth(row.original);
+          const m = row.original;
+          const h = nodeAwareHealth(
+            claimHealth(m),
+            podIndex.nodesForApp(m.metadata.namespace, m.metadata.name),
+            offlineNodes,
+          );
           return <StatusBadge status={h.label} tone={h.tone} />;
         },
         size: 150,
@@ -86,7 +100,7 @@ export function ModelsPage() {
         size: 90,
       },
     ],
-    [],
+    [offlineNodes, podIndex],
   );
 
   return (

--- a/ui/src/features/workloads/columns.tsx
+++ b/ui/src/features/workloads/columns.tsx
@@ -1,7 +1,8 @@
 import { type ColumnDef } from "@tanstack/react-table";
+import { AlertTriangle } from "lucide-react";
 import { StatusBadge } from "@/components/common/status-badge";
 import { Badge } from "@/components/ui/badge";
-import { age, statusTone } from "@/lib/format";
+import { age, statusTone, type StatusTone } from "@/lib/format";
 import type { Deployment, Pod, Service } from "@/types/k8s";
 
 const nameCol = <T extends { metadata: { name: string } }>(): ColumnDef<
@@ -69,6 +70,22 @@ function podPhase(pod: Pod): string {
   return pod.status?.reason || pod.status?.phase || "Unknown";
 }
 
+/**
+ * What to show in the Status column. When the pod's node is offline, its
+ * reported phase (often still "Running") is stale, so we override it — this is
+ * what stops the Workloads view from claiming pods run on a dead node.
+ */
+function podStatusView(
+  pod: Pod,
+  offlineNodes: Set<string>,
+): { label: string; tone?: StatusTone } {
+  const node = pod.spec?.nodeName;
+  if (node && offlineNodes.has(node) && !pod.metadata.deletionTimestamp) {
+    return { label: "Node down", tone: "destructive" };
+  }
+  return { label: podPhase(pod) };
+}
+
 function podRestarts(pod: Pod): number {
   return (pod.status?.containerStatuses ?? []).reduce(
     (sum, s) => sum + (s.restartCount ?? 0),
@@ -76,52 +93,77 @@ function podRestarts(pod: Pod): number {
   );
 }
 
-export const podColumns: ColumnDef<Pod, unknown>[] = [
-  nameCol<Pod>(),
-  namespaceCol<Pod>(),
-  {
-    id: "ready",
-    header: "Ready",
-    accessorFn: (p) => podReady(p),
-    cell: ({ row }) => (
-      <span className="font-mono text-xs">{podReady(row.original)}</span>
-    ),
-    size: 80,
-  },
-  {
-    id: "status",
-    header: "Status",
-    accessorFn: (p) => podPhase(p),
-    cell: ({ row }) => <StatusBadge status={podPhase(row.original)} />,
-    size: 170,
-  },
-  {
-    id: "restarts",
-    header: "Restarts",
-    accessorFn: (p) => podRestarts(p),
-    cell: ({ row }) => {
-      const r = podRestarts(row.original);
-      return (
-        <span className={r > 0 ? "font-medium text-warning" : "text-muted-foreground"}>
-          {r}
-        </span>
-      );
+/**
+ * Pod columns are a factory (not a const) because Status and Node both depend on
+ * which nodes are currently offline — passed in from the Workloads page's node
+ * watch so the table can flag pods stranded on a dead node.
+ */
+export function podColumns(
+  offlineNodes: Set<string> = new Set(),
+): ColumnDef<Pod, unknown>[] {
+  return [
+    nameCol<Pod>(),
+    namespaceCol<Pod>(),
+    {
+      id: "ready",
+      header: "Ready",
+      accessorFn: (p) => podReady(p),
+      cell: ({ row }) => (
+        <span className="font-mono text-xs">{podReady(row.original)}</span>
+      ),
+      size: 80,
     },
-    size: 90,
-  },
-  {
-    id: "node",
-    header: "Node",
-    accessorFn: (p) => p.spec?.nodeName ?? "",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground">
-        {row.original.spec?.nodeName ?? "—"}
-      </span>
-    ),
-    size: 160,
-  },
-  ageCol<Pod>(),
-];
+    {
+      id: "status",
+      header: "Status",
+      accessorFn: (p) => podStatusView(p, offlineNodes).label,
+      cell: ({ row }) => {
+        const v = podStatusView(row.original, offlineNodes);
+        return <StatusBadge status={v.label} tone={v.tone} />;
+      },
+      size: 170,
+    },
+    {
+      id: "restarts",
+      header: "Restarts",
+      accessorFn: (p) => podRestarts(p),
+      cell: ({ row }) => {
+        const r = podRestarts(row.original);
+        return (
+          <span className={r > 0 ? "font-medium text-warning" : "text-muted-foreground"}>
+            {r}
+          </span>
+        );
+      },
+      size: 90,
+    },
+    {
+      id: "node",
+      header: "Node",
+      accessorFn: (p) => p.spec?.nodeName ?? "",
+      cell: ({ row }) => {
+        const node = row.original.spec?.nodeName;
+        if (!node) return <span className="text-muted-foreground">—</span>;
+        const offline = offlineNodes.has(node);
+        return (
+          <span
+            className={
+              offline
+                ? "flex items-center gap-1 font-medium text-destructive"
+                : "text-muted-foreground"
+            }
+            title={offline ? "Node is NotReady" : undefined}
+          >
+            {offline ? <AlertTriangle className="size-3.5" /> : null}
+            {node}
+          </span>
+        );
+      },
+      size: 180,
+    },
+    ageCol<Pod>(),
+  ];
+}
 
 /* ---------------------------- Deployments ---------------------------- */
 

--- a/ui/src/features/workloads/workloads-page.tsx
+++ b/ui/src/features/workloads/workloads-page.tsx
@@ -12,15 +12,17 @@ import {
 } from "@/features/workloads/columns";
 import { appsPaths, corePaths, resourcePaths } from "@/lib/k8s-paths";
 import { useNamespace } from "@/lib/namespace-context";
+import { useNodeHealth } from "@/hooks/use-node-health";
 import type { Deployment, Pod, Service } from "@/types/k8s";
 
 export function WorkloadsPage() {
   const { scoped } = useNamespace();
+  const { offlineNodes } = useNodeHealth();
 
   const podsConfig: ResourceTableConfig<Pod> = {
     kind: "Pod",
     listPath: corePaths.pods(scoped),
-    columns: podColumns,
+    columns: podColumns(offlineNodes),
     searchFields: (p) => [
       p.metadata.name,
       p.metadata.namespace,

--- a/ui/src/hooks/use-node-health.ts
+++ b/ui/src/hooks/use-node-health.ts
@@ -1,0 +1,31 @@
+import { useMemo } from "react";
+import { useK8sWatch } from "@/hooks/use-k8s-watch";
+import { corePaths } from "@/lib/k8s-paths";
+import { offlineNodeNames } from "@/lib/node-health";
+import type { Node } from "@/types/k8s";
+
+export interface NodeHealth {
+  /** Names of nodes that are NotReady/Unknown. */
+  offlineNodes: Set<string>;
+  /** True when the given node is offline (false for undefined / unknown nodes). */
+  isOffline: (nodeName?: string) => boolean;
+  /** False until the first node list has loaded — avoids flagging during load. */
+  loaded: boolean;
+}
+
+/**
+ * Live view of which cluster nodes are offline. Backed by the same node watch
+ * the Nodes page uses, so it shares the query cache (no extra API load).
+ */
+export function useNodeHealth(): NodeHealth {
+  const { items, isLoading } = useK8sWatch<Node>(corePaths.nodes());
+  const offlineNodes = useMemo(() => offlineNodeNames(items), [items]);
+  return useMemo(
+    () => ({
+      offlineNodes,
+      isOffline: (n?: string) => (n ? offlineNodes.has(n) : false),
+      loaded: !isLoading,
+    }),
+    [offlineNodes, isLoading],
+  );
+}

--- a/ui/src/hooks/use-pod-node-index.ts
+++ b/ui/src/hooks/use-pod-node-index.ts
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import { useK8sWatch } from "@/hooks/use-k8s-watch";
+import { corePaths } from "@/lib/k8s-paths";
+import type { Pod } from "@/types/k8s";
+
+/**
+ * Standard label every open-infra claim stamps on its backing pods
+ * (Application/Model deployments use `app.kubernetes.io/name=<claim-name>`).
+ * It's how we map a claim back to the node(s) actually running it.
+ */
+const APP_LABEL = "app.kubernetes.io/name";
+
+export interface PodNodeIndex {
+  /**
+   * Node names hosting pods labeled `app.kubernetes.io/name=<name>` in
+   * `<namespace>`. Empty when the claim has no scheduled pods (e.g. scaled to
+   * zero) or none could be found in the watched scope.
+   */
+  nodesForApp: (namespace: string | undefined, name: string | undefined) => string[];
+  loaded: boolean;
+}
+
+/**
+ * Indexes pods in `scope` by their `app.kubernetes.io/name` label so callers can
+ * ask "which node(s) is claim X running on?". Pass a concrete namespace to keep
+ * the watch small; pass undefined to index the whole cluster.
+ */
+export function usePodNodeIndex(scope?: string): PodNodeIndex {
+  const { items, isLoading } = useK8sWatch<Pod>(corePaths.pods(scope));
+  const index = useMemo(() => {
+    const m = new Map<string, Set<string>>();
+    for (const p of items) {
+      const app = p.metadata.labels?.[APP_LABEL];
+      const node = p.spec?.nodeName;
+      if (!app || !node) continue;
+      const key = `${p.metadata.namespace ?? ""}/${app}`;
+      const set = m.get(key) ?? new Set<string>();
+      set.add(node);
+      m.set(key, set);
+    }
+    return m;
+  }, [items]);
+
+  return useMemo(
+    () => ({
+      nodesForApp: (ns, name) =>
+        name ? [...(index.get(`${ns ?? ""}/${name}`) ?? [])] : [],
+      loaded: !isLoading,
+    }),
+    [index, isLoading],
+  );
+}

--- a/ui/src/lib/node-health.ts
+++ b/ui/src/lib/node-health.ts
@@ -1,0 +1,24 @@
+import type { Node } from "@/types/k8s";
+
+/**
+ * Names of nodes that are not Ready (offline / unreachable).
+ *
+ * Kubernetes does NOT rewrite the status of pods/claims the moment their node
+ * drops off — a pod keeps `phase: Running` and a Crossplane claim keeps
+ * `Ready: True` for a grace period (until the node controller evicts the pods).
+ * The console reads those objects straight from the API, so without this the UI
+ * would faithfully report "Running"/"Ready" for workloads on a dead node. We use
+ * this offline set to refine what the user is shown.
+ */
+export function offlineNodeNames(nodes: Node[]): Set<string> {
+  const out = new Set<string>();
+  for (const n of nodes) {
+    const ready = n.status?.conditions?.find((c) => c.type === "Ready");
+    // Ready != "True" means NotReady or Unknown — both are "offline" to a user.
+    if (ready?.status !== "True") {
+      const name = n.metadata.name;
+      if (name) out.add(name);
+    }
+  }
+  return out;
+}

--- a/ui/src/lib/resource-health.ts
+++ b/ui/src/lib/resource-health.ts
@@ -31,3 +31,28 @@ export function claimHealth(
   if (conditions.length === 0) return { label: "Pending", tone: "warning" };
   return { label: "Provisioning", tone: "warning" };
 }
+
+/**
+ * Refine a claim's health with the liveness of the node(s) backing it.
+ *
+ * A claim keeps reporting `Ready` for a grace period after its node goes
+ * NotReady (Kubernetes hasn't evicted its pods yet), so a "Ready" Model/App
+ * whose pods all sit on offline nodes is really unreachable. `nodes` are the
+ * node names hosting the claim's pods; `offlineNodes` is the set of NotReady
+ * nodes. With no scheduled pods or no offline nodes, the base health stands.
+ */
+export function nodeAwareHealth(
+  base: Health,
+  nodes: string[],
+  offlineNodes: Set<string>,
+): Health {
+  if (!nodes.length || offlineNodes.size === 0) return base;
+  const offline = nodes.filter((n) => offlineNodes.has(n));
+  if (offline.length === 0) return base;
+  if (offline.length === nodes.length) {
+    // Every backing pod is on a dead node — the claim is not actually serving.
+    return { label: "Node offline", tone: "destructive" };
+  }
+  // Some replicas remain on healthy nodes: degraded, not down.
+  return { label: "Degraded", tone: "warning" };
+}


### PR DESCRIPTION
## What

The console showed pods as **Running** and Models as **Ready** even when the node hosting them was `NotReady`. It reads status straight from the Kubernetes API, and Kubernetes leaves a pod's phase / a claim's `Ready` condition stale for a grace period after a node drops off — so the UI faithfully hid stranded workloads.

Reproduced live: node `mlbox-g477` went NotReady, yet Model `demo-chat` reported `READY: True` for 12h while its only pod was stuck `Terminating` on the dead node.

## How

Client-side node-health awareness (consistent with the BFF-is-just-a-proxy architecture):

- `lib/node-health.ts` + `hooks/use-node-health.ts` — the set of offline nodes (Ready ≠ True), reusing the existing node watch (no extra API load).
- `hooks/use-pod-node-index.ts` — maps a claim's pods (`app.kubernetes.io/name`) to their hosting node(s).
- `lib/resource-health.ts` `nodeAwareHealth()` — downgrades a claim to **Node offline** (all backing pods on dead nodes) or **Degraded** (some).
- **Workloads → Pods**: shows **Node down** instead of stale "Running", and flags the offline node with a warning icon.
- **Models** list + detail: node-aware status badge; detail adds a **Node** row showing exactly where the model runs (and if that node is offline).

## Testing

- `tsc --noEmit` clean.
- `npm run build` in `node:22-alpine` (mirrors CI): 2993 modules, exit 0.

Closes #3
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)