### PR TITLE
fix(model): make Models stateless so they reschedule on node failure

### DIFF
--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -177,8 +177,12 @@ spec:
                   metadata: { name: {{ $name }}-limits, namespace: {{ $ns }} }
                   spec:
                     limits:
+                      # max is a safety ceiling against a runaway container, not a
+                      # tenant cap (the ResourceQuota bounds total usage). Keep it
+                      # generous enough for real workloads — e.g. a co-located Model's
+                      # Ollama container needs 8Gi; 4Gi here rejected it at admission.
                       - type: Container
-                        max: { cpu: "4", memory: 4Gi }
+                        max: { cpu: "8", memory: 16Gi }
                         default: { cpu: 500m, memory: 512Mi }
                         defaultRequest: { cpu: 50m, memory: 64Mi }
             ---

--- a/platform/abstraction/model-composition.yaml
+++ b/platform/abstraction/model-composition.yaml
@@ -39,23 +39,6 @@ spec:
             {{- $key := .observed.composite.resource.metadata.uid | sha256sum | trunc 32 }}
             {{- $svc := printf "%s.%s.svc.cluster.local" $name $ns }}
             ---
-            # --- PVC: cache Ollama model weights so they survive restarts ---
-            apiVersion: kubernetes.crossplane.io/v1alpha2
-            kind: Object
-            metadata:
-              annotations:
-                gotemplating.fn.crossplane.io/composition-resource-name: models-pvc
-            spec:
-              forProvider:
-                manifest:
-                  apiVersion: v1
-                  kind: PersistentVolumeClaim
-                  metadata: { name: {{ $name }}-models, namespace: {{ $ns }} }
-                  spec:
-                    accessModes: [ReadWriteOnce]
-                    storageClassName: local-path   # local NVMe; never CIFS/NFS
-                    resources: { requests: { storage: {{ $size }} } }
-            ---
             # --- Auth-proxy config (Secret so the key isn't in a plaintext CM).
             #     nginx $variables below are literal (not Go-template actions). ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
@@ -133,8 +116,13 @@ spec:
                               - { name: proxy-conf, mountPath: /etc/nginx/conf.d }
                             readinessProbe: { tcpSocket: { port: 8080 } }
                         volumes:
+                          # Ephemeral weight cache. Stateless by design: a node-local
+                          # PVC would pin the Model to one node (local-path PVs carry a
+                          # hostname nodeAffinity), so it could never reschedule when
+                          # that node fails. The startup `ollama pull` re-fetches weights
+                          # on any GPU node; sizeLimit bounds the scratch space.
                           - name: models
-                            persistentVolumeClaim: { claimName: {{ $name }}-models }
+                            emptyDir: { sizeLimit: {{ $size }} }
                           - name: proxy-conf
                             secret: { secretName: {{ $name }}-proxy-conf }
             ---


### PR DESCRIPTION
## What

Two reasons a `Model` couldn't recover when its node went offline:

1. It mounted a **`local-path` PVC** (Ollama weight cache). `local-path` PVs carry a hostname `nodeAffinity`, welding the Model to one node — it could never reschedule. (Also contradicted the *stateless-by-design* decision.)
2. The `Application` **LimitRange** capped container memory at `4Gi`, so the Model's `8Gi` pod was **rejected at admission** (`FailedCreate`) when co-located with an app.

## How

- **model-composition**: drop the PVC, use an `emptyDir` (keeps `sizeLimit` from `storageSize`). The startup `ollama pull` re-fetches weights on whatever GPU node it lands on, so the Model is now stateless and reschedulable.
- **composition**: raise the LimitRange container `max` to `cpu: 8 / memory: 16Gi` — a runaway-safety ceiling, not a tenant cap (the ResourceQuota bounds total usage).

## Testing

- `kubectl apply --dry-run=server` validates both Compositions.

Closes #8
Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)