### PR TITLE
feat(db): opt-in database.highAvailability for failover across nodes

### DIFF
--- a/cli/open-infra
+++ b/cli/open-infra
@@ -28,7 +28,7 @@ spec:
   port: 8080
   scaling: { min: 1, max: 5, targetCPUPercent: 70 }
   domain: ${name}.example            # dev mode rewrites this to sslip.io
-  # database: { engine: postgres, name: ${name}db }
+  # database: { engine: postgres, name: ${name}db }   # +highAvailability: true for failover
   # storage:  { buckets: [uploads] }
   # queues:   [jobs]
   # secrets:  [chat-model]           # inject a Model endpoint (see: init model)

--- a/examples/hello-web/infra.yaml
+++ b/examples/hello-web/infra.yaml
@@ -11,6 +11,7 @@ spec:
     - { name: GREETING, value: "hello from open-infra" }
   # Uncomment any of these — the platform provisions them and injects creds:
   # database: { engine: postgres, name: hellodb }   # -> DATABASE_URL
+  #   add highAvailability: true -> primary + standby on separate nodes, auto-failover
   # storage:  { buckets: [uploads] }                # -> MINIO_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKETS
   # queues:   [jobs]                                # -> NATS_URL, OPENINFRA_QUEUES
   # secrets:  [hello-extra]                         # -> envFrom that secret (e.g. a Sealed Secret)

--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -243,7 +243,17 @@ spec:
                   kind: Cluster
                   metadata: { name: {{ $name }}-db, namespace: {{ $ns }} }
                   spec:
-                    instances: 1            # 3 for prod HA
+                    # database.highAvailability -> primary + hot standby, streaming
+                    # replication, automatic failover. local-path PVs are node-local,
+                    # so anti-affinity (one instance per node) is what makes the DB
+                    # survive a node loss — the standby is promoted automatically.
+                    instances: {{ if $spec.database.highAvailability }}2{{ else }}1{{ end }}
+                    {{- if $spec.database.highAvailability }}
+                    affinity:
+                      enablePodAntiAffinity: true
+                      topologyKey: kubernetes.io/hostname
+                      podAntiAffinityType: required
+                    {{- end }}
                     storage:
                       size: 5Gi
                       storageClass: local-path   # NEVER CIFS/NFS

--- a/platform/abstraction/xrd.yaml
+++ b/platform/abstraction/xrd.yaml
@@ -49,6 +49,10 @@ spec:
                   properties:
                     engine: { type: string, enum: [postgres], default: postgres }
                     name:   { type: string }
+                    # Run a primary + standby on separate nodes with automatic
+                    # failover (CloudNativePG). Survives a node loss; needs >=2
+                    # nodes. Default false = single instance (fine for dev).
+                    highAvailability: { type: boolean, default: false }
                 storage:
                   type: object
                   properties:


### PR DESCRIPTION
## What

A single-instance Postgres on `local-path` storage goes down with its node and **cannot fail over** — the data physically lives on that node's disk. This adds an opt-in HA mode to `infra.yaml`.

```yaml
database:
  engine: postgres
  name: myapidb
  highAvailability: true   # primary + standby on separate nodes, auto-failover
```

## How

- **xrd**: new `database.highAvailability` boolean (default `false`).
- **composition**: when `true`, the CNPG `Cluster` runs **2 instances** with **required pod anti-affinity** (`topologyKey: kubernetes.io/hostname`), so the primary and standby land on different nodes. CNPG streams replication and **auto-promotes the standby** on node loss. Default stays single-instance so one-box `dev` works.
- Documented in the `hello-web` example and the `open-infra init` scaffold.

> Note: each instance still uses its own node-local PV — HA is achieved at the **database** layer (replication + failover), not the storage layer. Volume-level durability (e.g. Longhorn) remains a separate future option.

## Testing

- `kubectl apply --dry-run=server` validates the XRD and Composition.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)