### PR TITLE
feat(model): curated catalog, GPU tiers (+CPU-only), and HA

### DIFF
--- a/cli/open-infra
+++ b/cli/open-infra
@@ -43,11 +43,15 @@ kind: Model
 metadata:
   name: ${name}
 spec:
-  model: llama3.1:8b                 # any Ollama model tag (must fit the GPU's VRAM)
-  gpu: 1                             # GPUs to allocate
+  # Pick from the curated catalog (sets resources + GPU class automatically):
+  #   qwen2.5:0.5b, llama3.2:1b  -> nano  (CPU-only, ultra-fast)
+  #   llama3.2:3b                -> small (small GPU)
+  #   llama3.1:8b                -> standard (small GPU)
+  #   mixtral:8x7b               -> large (requires a large GPU)
+  model: llama3.1:8b
+  # highAvailability: true           # 2 replicas across nodes (degrades if GPUs scarce)
   # domain: ${name}.example          # optional: expose externally (Ingress + TLS)
-  # storageSize: 20Gi                # PVC for cached model weights
-# A GPU-backed, OpenAI-compatible endpoint gated by a generated API key. Apps
+# An OpenAI-compatible endpoint gated by a generated API key. Apps
 # consume it by referencing the secret '${name}-model' in their Application's
 # spec.secrets (injects OPENAI_BASE_URL / OPENAI_API_KEY / MODEL). See docs/gpu.md.
 EOF

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -39,7 +39,15 @@ that are intentionally NOT in the repo — they touch the host OS, not the clust
    ```bash
    kubectl label node <node> openinfra.dev/gpu=true
    kubectl label node <node> openinfra.dev/gpu-model=RTX-3090-24GB   # optional; shown in the console
+   # GPU class for Model placement — "large" for >=24GB cards, "small" otherwise:
+   kubectl label node <node> openinfra.dev/gpu-tier=large            # or: small
    ```
+
+   `gpu-tier` is how the **Model catalog** right-sizes placement: `small`/`standard`
+   models prefer a `small` GPU (but may use a `large` one), `large` models require a
+   `large` GPU, and `nano` (CPU-only) models need no GPU at all. See
+   [`docs/serverless.md`](serverless.md) and the catalog in
+   `platform/abstraction/model-composition.yaml`.
 
 Confirm GPUs are now advertised to the scheduler:
 
@@ -83,15 +91,40 @@ kind: Model
 metadata:
   name: chat
 spec:
-  model: llama3.1:8b      # any Ollama model tag
-  gpu: 1                  # GPUs to allocate (default 1)
-  # domain: chat.example  # optional: expose externally (Ingress + TLS)
-  # storageSize: 20Gi     # PVC for cached weights (default 20Gi)
+  model: llama3.1:8b          # from the curated catalog (below)
+  # highAvailability: true    # 2 replicas across nodes; degrades if GPUs are scarce
+  # domain: chat.example      # optional: expose externally (Ingress + TLS)
 ```
+
+### Catalog (allowlist + right-sizing)
+
+`spec.model` is an **enum** — only vetted models are allowed, and each maps to a
+tier that sets CPU/RAM and GPU placement (no manual `gpu` count). Keep the XRD
+enum and the Composition `$catalog` in sync when adding models.
+
+| `model` | Tier | Hardware | CPU / RAM |
+|---|---|---|---|
+| `qwen2.5:0.5b`, `llama3.2:1b` | nano | **CPU-only** (no GPU) | 2 / 4Gi |
+| `llama3.2:3b` | small | small GPU (may use large) | 4 / 8Gi |
+| `llama3.1:8b` | standard | small GPU (may use large) | 4 / 12Gi |
+| `mixtral:8x7b` | large | **requires** a large GPU | 8 / 16Gi |
+
+GPU placement uses the node label `openinfra.dev/gpu-tier` (`small`/`large`) — see
+§1. `nano` needs no GPU and runs on any node.
+
+### High availability
+
+`highAvailability: true` runs **2 replicas with pod anti-affinity** (one per node),
+load-balanced by the Service — so a node loss doesn't drop the endpoint. Because a
+GPU can't be split, **each replica needs its own GPU node**: a `large` model (only
+one big-GPU node) or any model when GPU nodes are scarce **degrades gracefully** to
+one replica, surfaced in the console as `Degraded (1/2)` rather than a false "Ready".
 
 The `model` Crossplane Composition compiles this into:
 
-- an **Ollama** Deployment on a GPU node (pulls + caches the model on a PVC),
+- an **Ollama** Deployment placed per the catalog tier (CPU-only or the right GPU
+  class), with the weight cache on an ephemeral `emptyDir` (stateless — so it can
+  reschedule on node failure),
 - an **nginx auth sidecar** enforcing `Authorization: Bearer <key>`,
 - a **Service** (the endpoint), plus optional **Ingress** + TLS,
 - a connection **Secret `<name>-model`** with `OPENAI_BASE_URL`, `OPENAI_API_KEY`,
@@ -118,8 +151,12 @@ Bedrock), so one Model can be shared across namespaces.
 
 ## Notes & sizing
 
-- The model is pulled once and cached on the PVC; the first start is slower.
-- Pick a model that fits the GPU's VRAM (e.g. `llama3.1:8b` ≈ 5–6 GB quantized;
-  a 24 GB card comfortably runs 8–14B models).
-- A rolling update can't share a single GPU / RWO PVC, so the Deployment uses the
-  `Recreate` strategy (brief downtime when the spec changes).
+- The catalog already right-sizes each model to a GPU class that fits its VRAM —
+  pick the tier that matches your latency/quality needs (nano for ultra-fast/CPU,
+  large only when you need it).
+- Weights are pulled on each fresh pod into an ephemeral `emptyDir` (the Model is
+  stateless so it can reschedule on node failure); the first start is slower.
+- A rolling update can't share a single GPU, so the Deployment uses the `Recreate`
+  strategy (brief downtime when the spec changes).
+- Adding a model = add it to **both** the XRD enum (`model-xrd.yaml`) and the
+  Composition `$catalog` (`model-composition.yaml`).

--- a/platform/abstraction/model-composition.yaml
+++ b/platform/abstraction/model-composition.yaml
@@ -1,8 +1,11 @@
-# The compiler for kind: Model -> a GPU-backed Ollama server + an nginx auth
-# sidecar that gates the OpenAI-compatible endpoint behind a generated API key,
-# + a PVC for cached weights, + a Service, + (optional) Ingress, + a connection
-# Secret (<name>-model: OPENAI_BASE_URL / OPENAI_API_KEY / MODEL) that apps
-# reference the same way they reference the database secret.
+# The compiler for kind: Model -> an Ollama server + an nginx auth sidecar that
+# gates the OpenAI-compatible endpoint behind a generated API key, + a Service,
+# + (optional) Ingress, + a connection Secret (<name>-model: OPENAI_BASE_URL /
+# OPENAI_API_KEY / MODEL) that apps reference like the database secret.
+#
+# Resources/placement are driven by a curated catalog ($catalog below, in sync
+# with the XRD enum): each model maps to a tier (cpu / smallgpu / largegpu) that
+# sets CPU/RAM and GPU targeting. highAvailability runs 2 replicas across nodes.
 #
 # The API key is derived deterministically from the composite's UID, so it is
 # stable across reconciles (re-rendering must not churn the key).
@@ -34,10 +37,23 @@ spec:
             {{- $labels := .observed.composite.resource.metadata.labels | default dict }}
             {{- $name := (index $labels "crossplane.io/claim-name") | default .observed.composite.resource.metadata.name }}
             {{- $ns := (index $labels "crossplane.io/claim-namespace") | default "default" }}
-            {{- $gpu := $spec.gpu | default 1 }}
             {{- $size := $spec.storageSize | default "20Gi" }}
             {{- $key := .observed.composite.resource.metadata.uid | sha256sum | trunc 32 }}
             {{- $svc := printf "%s.%s.svc.cluster.local" $name $ns }}
+            {{- /* Curated catalog: model tag -> resource profile. KEEP IN SYNC with
+                   the XRD enum. tier drives GPU placement: cpu (no GPU, runs
+                   anywhere), smallgpu (A2000 class, may use a large GPU), largegpu
+                   (requires a large GPU). */}}
+            {{- $catalog := dict
+                  "qwen2.5:0.5b" (dict "tier" "cpu"      "cpu" "2" "memory" "4Gi")
+                  "llama3.2:1b"  (dict "tier" "cpu"      "cpu" "2" "memory" "4Gi")
+                  "llama3.2:3b"  (dict "tier" "smallgpu" "cpu" "4" "memory" "8Gi")
+                  "llama3.1:8b"  (dict "tier" "smallgpu" "cpu" "4" "memory" "12Gi")
+                  "mixtral:8x7b" (dict "tier" "largegpu" "cpu" "8" "memory" "16Gi") }}
+            {{- $profile := (index $catalog $spec.model) | default (dict "tier" "cpu" "cpu" "2" "memory" "4Gi") }}
+            {{- $tier := $profile.tier }}
+            {{- $useGpu := ne $tier "cpu" }}
+            {{- $replicas := 1 }}{{- if $spec.highAvailability }}{{- $replicas = 2 }}{{- end }}
             ---
             # --- Auth-proxy config (Secret so the key isn't in a plaintext CM).
             #     nginx $variables below are literal (not Go-template actions). ---
@@ -66,8 +82,9 @@ spec:
                         }
                       }
             ---
-            # --- Deployment: Ollama (GPU) + nginx auth sidecar. Recreate strategy
-            #     because the GPU + RWO PVC can't be shared during a rollover. ---
+            # --- Deployment: Ollama + nginx auth sidecar. Resources, GPU class, and
+            #     replica count all come from the catalog profile + highAvailability.
+            #     Recreate strategy: a GPU can't host two replicas during a rollover. ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
             kind: Object
             metadata:
@@ -83,25 +100,67 @@ spec:
                     namespace: {{ $ns }}
                     labels: { app.kubernetes.io/name: {{ $name }} }
                   spec:
+                    replicas: {{ $replicas }}
                     selector: { matchLabels: { app.kubernetes.io/name: {{ $name }} } }
                     strategy: { type: Recreate }
                     template:
                       metadata: { labels: { app.kubernetes.io/name: {{ $name }} } }
                       spec:
+                        {{- if $useGpu }}
                         runtimeClassName: nvidia
-                        nodeSelector: { openinfra.dev/gpu: "true" }
+                        {{- end }}
+                        {{- if or $useGpu $spec.highAvailability }}
+                        affinity:
+                          {{- if $useGpu }}
+                          # Target the right GPU class. largegpu requires a large GPU;
+                          # smallgpu prefers a small GPU but may use a large one (so it
+                          # doesn't strand on a single node), keeping big GPUs free.
+                          nodeAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              nodeSelectorTerms:
+                                - matchExpressions:
+                                    - key: openinfra.dev/gpu-tier
+                                      operator: In
+                                      {{- if eq $tier "largegpu" }}
+                                      values: [large]
+                                      {{- else }}
+                                      values: [small, large]
+                                      {{- end }}
+                            {{- if eq $tier "smallgpu" }}
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              - weight: 100
+                                preference:
+                                  matchExpressions:
+                                    - { key: openinfra.dev/gpu-tier, operator: In, values: [small] }
+                            {{- end }}
+                          {{- end }}
+                          {{- if $spec.highAvailability }}
+                          # Spread replicas across nodes. If too few qualifying nodes
+                          # exist, the extra replica stays Pending (graceful degrade).
+                          podAntiAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              - labelSelector:
+                                  matchLabels: { app.kubernetes.io/name: {{ $name }} }
+                                topologyKey: kubernetes.io/hostname
+                          {{- end }}
+                        {{- end }}
                         containers:
                           - name: ollama
                             image: ollama/ollama:0.30.10
-                            # Start the server, wait for it, pull the model once
-                            # (cached on the PVC), then hand the process back.
+                            # Start the server, wait for it, pull the model once, then
+                            # hand the process back. Weights re-pull on each fresh pod.
                             command: ["/bin/sh", "-c"]
                             args:
                               - 'ollama serve & pid=$!; until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull {{ $spec.model }} || true; wait $pid'
                             ports: [ { containerPort: 11434 } ]
                             resources:
                               requests: { cpu: 250m, memory: 1Gi }
-                              limits: { cpu: "4", memory: 8Gi, nvidia.com/gpu: {{ $gpu }} }
+                              limits:
+                                cpu: "{{ $profile.cpu }}"
+                                memory: {{ $profile.memory }}
+                                {{- if $useGpu }}
+                                nvidia.com/gpu: 1
+                                {{- end }}
                             volumeMounts:
                               - { name: models, mountPath: /root/.ollama }
                             readinessProbe: { tcpSocket: { port: 11434 }, initialDelaySeconds: 5, periodSeconds: 10 }

--- a/platform/abstraction/model-xrd.yaml
+++ b/platform/abstraction/model-xrd.yaml
@@ -33,10 +33,24 @@ spec:
               type: object
               required: [model]
               properties:
-                model:       { type: string, description: "Ollama model tag, e.g. llama3.1:8b" }
-                gpu:         { type: integer, default: 1, description: "GPUs to allocate" }
+                # Curated catalog (allowlist). Each entry maps to a tier + resource
+                # profile in the Composition (CPU/RAM, GPU class, or CPU-only). This
+                # is the governance + right-sizing contract — adding a model means
+                # adding it here AND to the Composition's $catalog.
+                model:
+                  type: string
+                  description: "Model to serve (from the curated catalog)."
+                  enum:
+                    - qwen2.5:0.5b     # nano  · CPU-only · ultra-fast, tiny
+                    - llama3.2:1b      # nano  · CPU-only
+                    - llama3.2:3b      # small · GPU (A2000 class)
+                    - llama3.1:8b      # standard · GPU (A2000 class)
+                    - mixtral:8x7b     # large · requires a large GPU (3090 class)
+                # Run two replicas on separate nodes (load-balanced, survives a node
+                # loss). Degrades gracefully to one replica if GPU nodes are scarce.
+                highAvailability: { type: boolean, default: false }
                 domain:      { type: string, description: "Hostname for external Ingress + TLS" }
-                storageSize: { type: string, default: "20Gi", description: "PVC size for cached model weights" }
+                storageSize: { type: string, default: "20Gi", description: "Ephemeral weight-cache size limit (emptyDir)" }
             status:
               type: object
               properties:

--- a/ui/src/features/models/model-detail-page.tsx
+++ b/ui/src/features/models/model-detail-page.tsx
@@ -13,7 +13,7 @@ import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { LoadingState, ErrorState } from "@/components/common/states";
-import { claimHealth, nodeAwareHealth } from "@/lib/resource-health";
+import { modelHealth, modelDesiredReplicas } from "@/lib/resource-health";
 import { ApiError, k8sDelete, k8sGet, modelChat, type ChatMessage } from "@/lib/api";
 import { openinfraPaths } from "@/lib/k8s-paths";
 import { useNodeHealth } from "@/hooks/use-node-health";
@@ -158,7 +158,14 @@ export function ModelDetailPage() {
   const endpoint = decode(data["OPENAI_BASE_URL"]);
   const apiKey = decode(data["OPENAI_API_KEY"]);
   const nodes = podIndex.nodesForApp(namespace, name);
-  const health = nodeAwareHealth(claimHealth(model), nodes, offlineNodes);
+  const desiredReplicas = modelDesiredReplicas(model.spec?.highAvailability);
+  const readyReplicas = podIndex.statsForApp(namespace, name).ready;
+  const health = modelHealth(model, {
+    nodes,
+    offlineNodes,
+    ready: readyReplicas,
+    desired: desiredReplicas,
+  });
 
   return (
     <DetailShell
@@ -191,7 +198,25 @@ export function ModelDetailPage() {
           <Card>
             <CardContent className="divide-y divide-border p-0">
               <DetailRow label="Model">{model.spec?.model ?? "—"}</DetailRow>
-              <DetailRow label="GPUs">{model.spec?.gpu ?? 1}×</DetailRow>
+              <DetailRow label="High availability">
+                {model.spec?.highAvailability ? (
+                  <span
+                    className={cn(
+                      readyReplicas < desiredReplicas &&
+                        "font-medium text-warning",
+                    )}
+                  >
+                    On · {readyReplicas}/{desiredReplicas} replicas ready
+                    {readyReplicas < desiredReplicas
+                      ? " (degraded — GPU-limited?)"
+                      : ""}
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">
+                    Off (single replica)
+                  </span>
+                )}
+              </DetailRow>
               <DetailRow label="Namespace">{namespace}</DetailRow>
               <DetailRow label="Node">
                 {nodes.length === 0 ? (

--- a/ui/src/features/models/models-page.tsx
+++ b/ui/src/features/models/models-page.tsx
@@ -6,14 +6,28 @@ import { StatusBadge } from "@/components/common/status-badge";
 import { ResourceTablePage } from "@/components/common/resource-table-page";
 import { NewResourceDialog } from "@/components/common/new-resource-dialog";
 import { Button } from "@/components/ui/button";
-import { claimHealth, nodeAwareHealth } from "@/lib/resource-health";
+import { modelHealth, modelDesiredReplicas } from "@/lib/resource-health";
 import { useK8sWatch } from "@/hooks/use-k8s-watch";
 import { useNodeHealth } from "@/hooks/use-node-health";
-import { usePodNodeIndex } from "@/hooks/use-pod-node-index";
+import { usePodNodeIndex, type PodNodeIndex } from "@/hooks/use-pod-node-index";
 import { useNamespace } from "@/lib/namespace-context";
 import { corePaths, openinfraPaths } from "@/lib/k8s-paths";
 import { age } from "@/lib/format";
 import { MODELS_CRD_NAME, type K8sObject, type Model } from "@/types/k8s";
+
+/** Node-aware + replica-aware status for a Model row. */
+function modelStatus(
+  m: Model,
+  podIndex: PodNodeIndex,
+  offlineNodes: Set<string>,
+) {
+  return modelHealth(m, {
+    nodes: podIndex.nodesForApp(m.metadata.namespace, m.metadata.name),
+    offlineNodes,
+    ready: podIndex.statsForApp(m.metadata.namespace, m.metadata.name).ready,
+    desired: modelDesiredReplicas(m.spec?.highAvailability),
+  });
+}
 
 export function ModelsPage() {
   const navigate = useNavigate();
@@ -58,35 +72,35 @@ export function ModelsPage() {
         size: 220,
       },
       {
-        id: "gpu",
-        header: "GPU",
-        accessorFn: (m) => m.spec?.gpu ?? 1,
-        cell: ({ row }) => (
-          <span className="text-xs text-muted-foreground">
-            {row.original.spec?.gpu ?? 1}×
-          </span>
-        ),
-        size: 80,
+        id: "ha",
+        header: "HA",
+        accessorFn: (m) => (m.spec?.highAvailability ? "yes" : "no"),
+        cell: ({ row }) => {
+          const m = row.original;
+          if (!m.spec?.highAvailability)
+            return <span className="text-xs text-muted-foreground">—</span>;
+          const desired = modelDesiredReplicas(true);
+          const { ready } = podIndex.statsForApp(
+            m.metadata.namespace,
+            m.metadata.name,
+          );
+          return (
+            <span className="font-mono text-xs">
+              {ready}/{desired}
+            </span>
+          );
+        },
+        size: 70,
       },
       {
         id: "status",
         header: "Status",
-        accessorFn: (m) =>
-          nodeAwareHealth(
-            claimHealth(m),
-            podIndex.nodesForApp(m.metadata.namespace, m.metadata.name),
-            offlineNodes,
-          ).label,
+        accessorFn: (m) => modelStatus(m, podIndex, offlineNodes).label,
         cell: ({ row }) => {
-          const m = row.original;
-          const h = nodeAwareHealth(
-            claimHealth(m),
-            podIndex.nodesForApp(m.metadata.namespace, m.metadata.name),
-            offlineNodes,
-          );
+          const h = modelStatus(row.original, podIndex, offlineNodes);
           return <StatusBadge status={h.label} tone={h.tone} />;
         },
-        size: 150,
+        size: 160,
       },
       {
         id: "age",

--- a/ui/src/hooks/use-pod-node-index.ts
+++ b/ui/src/hooks/use-pod-node-index.ts
@@ -10,6 +10,13 @@ import type { Pod } from "@/types/k8s";
  */
 const APP_LABEL = "app.kubernetes.io/name";
 
+export interface AppStats {
+  /** Pods (this app) that are Running with all containers ready. */
+  ready: number;
+  /** Total pods seen for this app (incl. Pending/unschedulable). */
+  total: number;
+}
+
 export interface PodNodeIndex {
   /**
    * Node names hosting pods labeled `app.kubernetes.io/name=<name>` in
@@ -17,26 +24,43 @@ export interface PodNodeIndex {
    * zero) or none could be found in the watched scope.
    */
   nodesForApp: (namespace: string | undefined, name: string | undefined) => string[];
+  /** Ready/total pod counts for a claim — used to detect degraded HA. */
+  statsForApp: (namespace: string | undefined, name: string | undefined) => AppStats;
   loaded: boolean;
+}
+
+function podIsReady(p: Pod): boolean {
+  if (p.metadata.deletionTimestamp) return false;
+  if (p.status?.phase !== "Running") return false;
+  const cs = p.status?.containerStatuses ?? [];
+  return cs.length > 0 && cs.every((c) => c.ready);
+}
+
+interface Entry {
+  nodes: Set<string>;
+  ready: number;
+  total: number;
 }
 
 /**
  * Indexes pods in `scope` by their `app.kubernetes.io/name` label so callers can
- * ask "which node(s) is claim X running on?". Pass a concrete namespace to keep
- * the watch small; pass undefined to index the whole cluster.
+ * ask "which node(s) is claim X running on?" and "how many replicas are ready?".
+ * Pass a concrete namespace to keep the watch small; pass undefined to index the
+ * whole cluster.
  */
 export function usePodNodeIndex(scope?: string): PodNodeIndex {
   const { items, isLoading } = useK8sWatch<Pod>(corePaths.pods(scope));
   const index = useMemo(() => {
-    const m = new Map<string, Set<string>>();
+    const m = new Map<string, Entry>();
     for (const p of items) {
       const app = p.metadata.labels?.[APP_LABEL];
-      const node = p.spec?.nodeName;
-      if (!app || !node) continue;
+      if (!app) continue;
       const key = `${p.metadata.namespace ?? ""}/${app}`;
-      const set = m.get(key) ?? new Set<string>();
-      set.add(node);
-      m.set(key, set);
+      const e = m.get(key) ?? { nodes: new Set<string>(), ready: 0, total: 0 };
+      e.total += 1;
+      if (p.spec?.nodeName) e.nodes.add(p.spec.nodeName);
+      if (podIsReady(p)) e.ready += 1;
+      m.set(key, e);
     }
     return m;
   }, [items]);
@@ -44,7 +68,11 @@ export function usePodNodeIndex(scope?: string): PodNodeIndex {
   return useMemo(
     () => ({
       nodesForApp: (ns, name) =>
-        name ? [...(index.get(`${ns ?? ""}/${name}`) ?? [])] : [],
+        name ? [...(index.get(`${ns ?? ""}/${name}`)?.nodes ?? [])] : [],
+      statsForApp: (ns, name) => {
+        const e = name ? index.get(`${ns ?? ""}/${name}`) : undefined;
+        return { ready: e?.ready ?? 0, total: e?.total ?? 0 };
+      },
       loaded: !isLoading,
     }),
     [index, isLoading],

--- a/ui/src/lib/resource-health.ts
+++ b/ui/src/lib/resource-health.ts
@@ -56,3 +56,36 @@ export function nodeAwareHealth(
   // Some replicas remain on healthy nodes: degraded, not down.
   return { label: "Degraded", tone: "warning" };
 }
+
+/**
+ * Health for a Model, layering replica availability on top of the node-aware
+ * claim health. A highAvailability Model wants 2 replicas; if GPU nodes are
+ * scarce the extra one stays Pending, so we surface "Degraded (1/2)" rather
+ * than a flat "Ready" — the honest state for graceful HA degradation.
+ *
+ * `nodes`/`offlineNodes` feed nodeAwareHealth; `ready`/`desired` are the running
+ * vs wanted replica counts.
+ */
+export function modelHealth(
+  model: K8sObject<{ highAvailability?: boolean }, { conditions?: Condition[] }>,
+  ctx: {
+    nodes: string[];
+    offlineNodes: Set<string>;
+    ready: number;
+    desired: number;
+  },
+): Health {
+  const base = nodeAwareHealth(claimHealth(model), ctx.nodes, ctx.offlineNodes);
+  if (model.metadata.deletionTimestamp) return base;
+  // Only refine when at least one replica is up — zero ready means base health
+  // (Node offline / Not ready / Provisioning) is the more accurate story.
+  if (ctx.desired > 1 && ctx.ready >= 1 && ctx.ready < ctx.desired) {
+    return { label: `Degraded (${ctx.ready}/${ctx.desired})`, tone: "warning" };
+  }
+  return base;
+}
+
+/** Desired replica count for a Model given its HA setting. */
+export function modelDesiredReplicas(highAvailability?: boolean): number {
+  return highAvailability ? 2 : 1;
+}

--- a/ui/src/types/k8s.ts
+++ b/ui/src/types/k8s.ts
@@ -209,6 +209,8 @@ export const FUNCTIONS_CRD_NAME = "functions.openinfra.dev";
 export interface ModelSpec {
   model: string;
   gpu?: number;
+  /** Run two replicas across nodes (load-balanced, survives a node loss). */
+  highAvailability?: boolean;
   domain?: string;
   storageSize?: string;
 }


### PR DESCRIPTION
## What

Adds governance + right-sizing + availability to `kind: Model`. Previously a Model took any Ollama tag with hardcoded resources (cpu4/mem8Gi/gpu1) and ran a single replica — a tiny app could reserve a whole GPU, nothing stopped an oversized model, and a node loss meant downtime.

## How

**Catalog (allowlist + right-sizing)** — `spec.model` is now an **enum**; each entry maps in the Composition's `$catalog` to a tier + resource profile (no manual `gpu`).

| `model` | Tier | Hardware | CPU / RAM |
|---|---|---|---|
| `qwen2.5:0.5b`, `llama3.2:1b` | nano | **CPU-only** | 2 / 4Gi |
| `llama3.2:3b` | small | small GPU (may use large) | 4 / 8Gi |
| `llama3.1:8b` | standard | small GPU (may use large) | 4 / 12Gi |
| `mixtral:8x7b` | large | **requires** large GPU | 8 / 16Gi |

**GPU tiers** — new node label `openinfra.dev/gpu-tier` (small/large). `nodeAffinity`: large *requires* large; small/standard *require* {small,large} but *prefer* small (keeps big GPUs free); nano requests no GPU.

**HA + graceful degrade** — `highAvailability: true` → 2 replicas + pod anti-affinity (one per node). A GPU can't be split, so when qualifying GPU nodes are scarce the extra replica stays Pending and the console shows **`Degraded (1/2)`** rather than a false "Ready".

**Console** — `usePodNodeIndex` now reports ready/total replicas; `modelHealth()` surfaces the degrade state (layered on node-aware health); Models list gains an HA column and detail an HA/replicas row; the New Model dialog renders the enum as a dropdown + HA checkbox (schema-driven).

## Testing

- Rendered the Composition offline with the real Sprig engine across every tier + HA path; all produce valid, correctly-nested YAML (replicas, nodeAffinity required+preferred, podAntiAffinity).
- `kubectl apply --dry-run=server` validates XRD + Composition.
- `tsc --noEmit` + `npm run build` (node:22) green.
- Node labels applied live (cake=small/A2000, mlbox=large/3090).

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)