### PR TITLE
feat(console): test Functions from the UI

### DIFF
--- a/console-api/cmd/server/main.go
+++ b/console-api/cmd/server/main.go
@@ -171,6 +171,8 @@ func newRouter(client *k8s.Client, logger *slog.Logger) http.Handler {
 			Delete("/buckets/{bucket}/object", handleDeleteObject(*client.Clientset, logger))
 		api.With(middleware.Timeout(125*time.Second)).
 			Post("/models/{namespace}/{name}/chat", handleModelChat(*client.Clientset, logger))
+		api.With(middleware.Timeout(65*time.Second)).
+			Post("/functions/{namespace}/{name}/invoke", handleFunctionInvoke(*client.Clientset, logger))
 		api.With(middleware.Timeout(10*time.Second)).
 			Post("/queues/publish", handleQueuePublish(logger))
 		api.With(middleware.Timeout(15*time.Second)).

--- a/console-api/cmd/server/services.go
+++ b/console-api/cmd/server/services.go
@@ -380,3 +380,84 @@ func handleModelChat(cs kubernetes.Interface, logger *slog.Logger) http.HandlerF
 		_, _ = io.Copy(w, resp.Body)
 	}
 }
+
+// handleFunctionInvoke proxies a test request from the console to a Knative
+// function's cluster-internal Service. The browser can't reach
+// <name>.<ns>.svc.cluster.local directly, so the BFF forwards it (and the call
+// wakes a scaled-to-zero function). The target host is fixed to the function's
+// own Service — only method/path/headers/body are caller-controlled — and we
+// verify the Service exists first, so this can't be used to hit arbitrary
+// in-cluster endpoints.
+func handleFunctionInvoke(cs kubernetes.Interface, logger *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ns := chi.URLParam(r, "namespace")
+		name := chi.URLParam(r, "name")
+		if _, err := cs.CoreV1().Services(ns).Get(r.Context(), name, metav1.GetOptions{}); err != nil {
+			writeError(w, http.StatusNotFound, "function service not found")
+			return
+		}
+
+		var in struct {
+			Method  string            `json:"method"`
+			Path    string            `json:"path"`
+			Headers map[string]string `json:"headers"`
+			Body    string            `json:"body"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		method := strings.ToUpper(strings.TrimSpace(in.Method))
+		if method == "" {
+			method = http.MethodGet
+		}
+		reqPath := in.Path
+		if reqPath == "" {
+			reqPath = "/"
+		} else if !strings.HasPrefix(reqPath, "/") {
+			reqPath = "/" + reqPath
+		}
+		target := fmt.Sprintf("http://%s.%s.svc.cluster.local%s", name, ns, reqPath)
+
+		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancel()
+		var body io.Reader
+		if in.Body != "" {
+			body = strings.NewReader(in.Body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, target, body)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "bad request: "+err.Error())
+			return
+		}
+		for k, v := range in.Headers {
+			if k != "" {
+				req.Header.Set(k, v)
+			}
+		}
+
+		start := time.Now()
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			logger.Error("function invoke", slog.String("error", err.Error()))
+			writeError(w, http.StatusBadGateway, "function unreachable: "+err.Error())
+			return
+		}
+		defer resp.Body.Close()
+		// Cap the captured body so a chatty function can't exhaust memory.
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		durMs := time.Since(start).Milliseconds()
+
+		hdrs := map[string]string{}
+		for k := range resp.Header {
+			hdrs[k] = resp.Header.Get(k)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":     resp.StatusCode,
+			"durationMs": durMs,
+			"headers":    hdrs,
+			"body":       string(respBody),
+		})
+	}
+}

--- a/ui/src/features/functions/function-detail-page.tsx
+++ b/ui/src/features/functions/function-detail-page.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ExternalLink, Trash2, Zap } from "lucide-react";
+import { ExternalLink, Send, Trash2, Zap } from "lucide-react";
 import { DetailShell } from "@/components/common/detail-shell";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DetailRow } from "@/components/common/detail-row";
@@ -13,9 +14,109 @@ import { GrafanaEmbed } from "@/components/common/grafana-embed";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { LoadingState, ErrorState } from "@/components/common/states";
 import { claimHealth } from "@/lib/resource-health";
-import { k8sDelete, k8sGet } from "@/lib/api";
+import {
+  ApiError,
+  invokeFunction,
+  k8sDelete,
+  k8sGet,
+  type FunctionInvokeResponse,
+} from "@/lib/api";
 import { openinfraPaths } from "@/lib/k8s-paths";
 import type { OpenInfraFunction } from "@/types/k8s";
+
+const METHODS = ["GET", "POST", "PUT", "DELETE"] as const;
+
+/** Send a test request to the function through the BFF and show the response. */
+function FunctionTester({
+  namespace,
+  name,
+}: {
+  namespace: string;
+  name: string;
+}) {
+  const [method, setMethod] = useState<string>("GET");
+  const [path, setPath] = useState("/");
+  const [body, setBody] = useState("");
+  const [result, setResult] = useState<FunctionInvokeResponse | null>(null);
+
+  const invoke = useMutation({
+    mutationFn: () =>
+      invokeFunction(namespace, name, {
+        method,
+        path,
+        body: body.trim() ? body : undefined,
+      }),
+    onSuccess: setResult,
+  });
+  const hasBody = method === "POST" || method === "PUT";
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex gap-2">
+        <select
+          value={method}
+          onChange={(e) => setMethod(e.target.value)}
+          className="rounded-md border border-border bg-background px-2 text-sm"
+          aria-label="HTTP method"
+        >
+          {METHODS.map((m) => (
+            <option key={m}>{m}</option>
+          ))}
+        </select>
+        <Input
+          value={path}
+          onChange={(e) => setPath(e.target.value)}
+          placeholder="/"
+          onKeyDown={(e) => {
+            if (e.key === "Enter") invoke.mutate();
+          }}
+        />
+        <Button onClick={() => invoke.mutate()} disabled={invoke.isPending}>
+          <Send className="size-4" />
+          Send
+        </Button>
+      </div>
+      {hasBody ? (
+        <textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Request body (optional)"
+          className="min-h-[80px] rounded-md border border-border bg-background p-2 font-mono text-xs"
+        />
+      ) : null}
+      <p className="text-xs text-muted-foreground">
+        Calls the function in-cluster through the console. The first request may
+        be slow — it wakes a scaled-to-zero function.
+      </p>
+      {invoke.isPending ? (
+        <p className="text-sm text-muted-foreground">…invoking</p>
+      ) : null}
+      {invoke.isError ? (
+        <p className="text-sm text-destructive">
+          ⚠{" "}
+          {invoke.error instanceof ApiError
+            ? invoke.error.message
+            : "request failed"}
+        </p>
+      ) : null}
+      {result ? (
+        <Card>
+          <CardContent className="space-y-2 p-4">
+            <div className="flex items-center gap-2 text-sm">
+              <Badge variant={result.status < 400 ? "secondary" : "destructive"}>
+                {result.status}
+              </Badge>
+              <span className="text-muted-foreground">{result.durationMs} ms</span>
+            </div>
+            <pre className="max-h-[320px] overflow-auto whitespace-pre-wrap rounded-md bg-secondary p-3 text-xs">
+              {result.body || "(empty body)"}
+            </pre>
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}
 
 export function FunctionDetailPage() {
   const { namespace, name } = useParams({ strict: false }) as {
@@ -57,12 +158,17 @@ export function FunctionDetailPage() {
         </Button>
       }
     >
-      <Tabs defaultValue="overview">
+      <Tabs defaultValue="test">
         <TabsList>
+          <TabsTrigger value="test">Test</TabsTrigger>
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="monitoring">Monitoring</TabsTrigger>
           <TabsTrigger value="yaml">YAML</TabsTrigger>
         </TabsList>
+
+        <TabsContent value="test" className="pt-4">
+          <FunctionTester namespace={namespace} name={name} />
+        </TabsContent>
 
         <TabsContent value="overview" className="pt-4">
           <Card>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -279,3 +279,29 @@ export function modelChat(
     },
   );
 }
+
+export interface FunctionInvokeRequest {
+  method: string;
+  path: string;
+  body?: string;
+  headers?: Record<string, string>;
+}
+export interface FunctionInvokeResponse {
+  status: number;
+  durationMs: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+/** Send a test request to a Function via the BFF (which reaches the in-cluster
+ *  Service the browser can't). Wakes a scaled-to-zero function. */
+export function invokeFunction(
+  namespace: string,
+  name: string,
+  req: FunctionInvokeRequest,
+): Promise<FunctionInvokeResponse> {
+  return request<FunctionInvokeResponse>(
+    `/functions/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/invoke`,
+    { method: "POST", body: JSON.stringify(req) },
+  );
+}


### PR DESCRIPTION
## What

Functions had no way to be invoked from the console (Models have a playground; Functions had nothing — issue #5). Adds a **Test** panel to the Function detail page.

## How

- **BFF**: `POST /api/functions/{ns}/{name}/invoke` proxies the request to the function's cluster-internal Service (`<name>.<ns>.svc.cluster.local`, which the browser can't reach) and returns `status / headers / body / durationMs`. The call also wakes a scaled-to-zero function.
- **Safety**: the target host is fixed to the function's own Service (only method/path/headers/body are caller-controlled), the Service must exist (verified first), and the response body is capped at 1 MiB — so it can't be used to hit arbitrary in-cluster endpoints.
- **Console**: a **Test** tab — pick method/path/body, Send, see status + latency + response. Notes the first call may be slow (cold start).
- `api.ts`: `invokeFunction` client.

## Testing

- `go build ./...` (BFF) green.
- `tsc --noEmit` + `npm run build` (node:22) green.
- Verified console SA can `get` Services; no NetworkPolicy isolates `demo-fn`, so the in-cluster call isn't blocked.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)