### PR TITLE
feat(console): discover function routes + methods in the test bench

### DIFF
--- a/console-api/cmd/server/main.go
+++ b/console-api/cmd/server/main.go
@@ -171,6 +171,8 @@ func newRouter(client *k8s.Client, logger *slog.Logger) http.Handler {
 			Delete("/buckets/{bucket}/object", handleDeleteObject(*client.Clientset, logger))
 		api.With(middleware.Timeout(125*time.Second)).
 			Post("/models/{namespace}/{name}/chat", handleModelChat(*client.Clientset, logger))
+		api.With(middleware.Timeout(30*time.Second)).
+			Get("/functions/{namespace}/{name}/routes", handleFunctionRoutes(*client.Clientset, logger))
 		api.With(middleware.Timeout(65*time.Second)).
 			Post("/functions/{namespace}/{name}/invoke", handleFunctionInvoke(*client.Clientset, logger))
 		api.With(middleware.Timeout(10*time.Second)).

--- a/console-api/cmd/server/services.go
+++ b/console-api/cmd/server/services.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -378,6 +379,96 @@ func handleModelChat(cs kubernetes.Interface, logger *slog.Logger) http.HandlerF
 		}
 		w.WriteHeader(resp.StatusCode)
 		_, _ = io.Copy(w, resp.Body)
+	}
+}
+
+// openAPIMethods are the OpenAPI/Swagger path-item keys that denote HTTP verbs
+// (a path item also carries non-verb keys like "parameters"/"summary").
+var openAPIMethods = map[string]bool{
+	"get": true, "post": true, "put": true, "delete": true,
+	"patch": true, "head": true, "options": true,
+}
+
+// functionRoute is one discovered endpoint: a path and the methods it accepts.
+type functionRoute struct {
+	Path    string   `json:"path"`
+	Methods []string `json:"methods"`
+}
+
+// handleFunctionRoutes discovers a function's routes by probing it for an
+// OpenAPI/Swagger document at well-known locations. If one is found, we return
+// its paths and the methods each accepts so the console can offer a route
+// dropdown and per-route method filtering. Functions that expose no spec return
+// source="none" and the UI falls back to a free-form path + all methods — there
+// is no universal way to enumerate an arbitrary HTTP server's routes.
+func handleFunctionRoutes(cs kubernetes.Interface, logger *slog.Logger) http.HandlerFunc {
+	specLocations := []string{
+		"/openapi.json", "/swagger.json", "/v3/api-docs",
+		"/q/openapi.json", "/swagger/v1/swagger.json", "/openapi",
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		ns := chi.URLParam(r, "namespace")
+		name := chi.URLParam(r, "name")
+		if _, err := cs.CoreV1().Services(ns).Get(r.Context(), name, metav1.GetOptions{}); err != nil {
+			writeError(w, http.StatusNotFound, "function service not found")
+			return
+		}
+		base := fmt.Sprintf("http://%s.%s.svc.cluster.local", name, ns)
+
+		var doc struct {
+			Paths map[string]map[string]json.RawMessage `json:"paths"`
+		}
+		foundAt := ""
+		for _, loc := range specLocations {
+			ctx, cancel := context.WithTimeout(r.Context(), 4*time.Second)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+loc, nil)
+			if err != nil {
+				cancel()
+				continue
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				cancel()
+				continue
+			}
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+			resp.Body.Close()
+			cancel()
+			if resp.StatusCode != http.StatusOK {
+				continue
+			}
+			doc.Paths = nil
+			if err := json.Unmarshal(body, &doc); err == nil && len(doc.Paths) > 0 {
+				foundAt = loc
+				break
+			}
+		}
+
+		routes := []functionRoute{}
+		for p, ops := range doc.Paths {
+			methods := []string{}
+			for m := range ops {
+				if openAPIMethods[strings.ToLower(m)] {
+					methods = append(methods, strings.ToUpper(m))
+				}
+			}
+			if len(methods) > 0 {
+				sort.Strings(methods)
+				routes = append(routes, functionRoute{Path: p, Methods: methods})
+			}
+		}
+		sort.Slice(routes, func(i, j int) bool { return routes[i].Path < routes[j].Path })
+
+		source := "none"
+		if foundAt != "" {
+			source = "openapi"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"source":   source,
+			"specPath": foundAt,
+			"routes":   routes,
+		})
 	}
 }
 

--- a/ui/src/features/functions/function-detail-page.tsx
+++ b/ui/src/features/functions/function-detail-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ExternalLink, Send, Trash2, Zap } from "lucide-react";
@@ -16,6 +16,7 @@ import { LoadingState, ErrorState } from "@/components/common/states";
 import { claimHealth } from "@/lib/resource-health";
 import {
   ApiError,
+  getFunctionRoutes,
   invokeFunction,
   k8sDelete,
   k8sGet,
@@ -24,9 +25,12 @@ import {
 import { openinfraPaths } from "@/lib/k8s-paths";
 import type { OpenInfraFunction } from "@/types/k8s";
 
-const METHODS = ["GET", "POST", "PUT", "DELETE"] as const;
+const ALL_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH"];
 
-/** Send a test request to the function through the BFF and show the response. */
+/** Send a test request to the function through the BFF and show the response.
+ *  Routes + allowed methods are discovered from the function's OpenAPI spec
+ *  (if it exposes one); otherwise we fall back to a free-form path + all
+ *  methods. */
 function FunctionTester({
   namespace,
   name,
@@ -34,10 +38,40 @@ function FunctionTester({
   namespace: string;
   name: string;
 }) {
+  const { data: routesData } = useQuery({
+    queryKey: ["function-routes", namespace, name],
+    queryFn: () => getFunctionRoutes(namespace, name),
+    staleTime: 60_000,
+  });
+  const routes = routesData?.routes ?? [];
+  const discovered = routesData?.source === "openapi" && routes.length > 0;
+
   const [method, setMethod] = useState<string>("GET");
   const [path, setPath] = useState("/");
   const [body, setBody] = useState("");
   const [result, setResult] = useState<FunctionInvokeResponse | null>(null);
+  const [initialized, setInitialized] = useState(false);
+
+  // Seed from the first discovered route once the spec loads.
+  useEffect(() => {
+    const first = routes[0];
+    if (!initialized && discovered && first) {
+      setPath(first.path);
+      setMethod(first.methods[0] ?? "GET");
+      setInitialized(true);
+    }
+  }, [initialized, discovered, routes]);
+
+  // Methods offered = the matching route's methods (so unsupported verbs aren't
+  // shown), or all methods when the path isn't a known route / no spec exists.
+  const matched = routes.find((r) => r.path === path);
+  const availableMethods = matched ? matched.methods : ALL_METHODS;
+
+  const onPathChange = (next: string) => {
+    setPath(next);
+    const r = routes.find((rt) => rt.path === next);
+    if (r && !r.methods.includes(method)) setMethod(r.methods[0] ?? "GET");
+  };
 
   const invoke = useMutation({
     mutationFn: () =>
@@ -48,7 +82,8 @@ function FunctionTester({
       }),
     onSuccess: setResult,
   });
-  const hasBody = method === "POST" || method === "PUT";
+  const hasBody = method === "POST" || method === "PUT" || method === "PATCH";
+  const listId = `routes-${namespace}-${name}`;
 
   return (
     <div className="flex flex-col gap-3">
@@ -59,18 +94,26 @@ function FunctionTester({
           className="rounded-md border border-border bg-background px-2 text-sm"
           aria-label="HTTP method"
         >
-          {METHODS.map((m) => (
+          {availableMethods.map((m) => (
             <option key={m}>{m}</option>
           ))}
         </select>
         <Input
           value={path}
-          onChange={(e) => setPath(e.target.value)}
+          onChange={(e) => onPathChange(e.target.value)}
           placeholder="/"
+          list={discovered ? listId : undefined}
           onKeyDown={(e) => {
             if (e.key === "Enter") invoke.mutate();
           }}
         />
+        {discovered ? (
+          <datalist id={listId}>
+            {routes.map((r) => (
+              <option key={r.path} value={r.path} />
+            ))}
+          </datalist>
+        ) : null}
         <Button onClick={() => invoke.mutate()} disabled={invoke.isPending}>
           <Send className="size-4" />
           Send
@@ -85,8 +128,10 @@ function FunctionTester({
         />
       ) : null}
       <p className="text-xs text-muted-foreground">
-        Calls the function in-cluster through the console. The first request may
-        be slow — it wakes a scaled-to-zero function.
+        {discovered
+          ? `${routes.length} route${routes.length > 1 ? "s" : ""} discovered from the function's OpenAPI spec — pick one (methods filter to what each route allows).`
+          : "No OpenAPI spec exposed by this function, so routes can't be auto-discovered — enter a path and method manually."}{" "}
+        The first request may be slow — it wakes a scaled-to-zero function.
       </p>
       {invoke.isPending ? (
         <p className="text-sm text-muted-foreground">…invoking</p>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -305,3 +305,24 @@ export function invokeFunction(
     { method: "POST", body: JSON.stringify(req) },
   );
 }
+
+export interface FunctionRoute {
+  path: string;
+  methods: string[];
+}
+export interface FunctionRoutes {
+  /** "openapi" if a spec was discovered, else "none" (free-form fallback). */
+  source: "openapi" | "none";
+  specPath: string;
+  routes: FunctionRoute[];
+}
+
+/** Discover a function's routes + allowed methods from its OpenAPI spec (if any). */
+export function getFunctionRoutes(
+  namespace: string,
+  name: string,
+): Promise<FunctionRoutes> {
+  return request<FunctionRoutes>(
+    `/functions/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/routes`,
+  );
+}


### PR DESCRIPTION
## What

Follow-up to the Function test bench (#5): instead of expecting users to know a function's routes and methods, the bench now **discovers** them.

- **Route dropdown + autocomplete**: the path field is a `datalist` combobox populated from the function's routes.
- **Method filtering**: the method dropdown shows only the verbs the selected route allows (e.g. a route with no POST won't offer POST).

## How

- **BFF** `GET /api/functions/{ns}/{name}/routes` probes the function for an OpenAPI/Swagger document at well-known locations (`/openapi.json`, `/swagger.json`, `/v3/api-docs`, `/q/openapi.json`, …) and returns `[{path, methods}]`.
- There is no universal way to enumerate an arbitrary HTTP server's routes, so when no spec is found it returns `source: "none"` and the console **falls back** to a free-form path + all methods, with a note explaining why.

## Testing

- `go build ./...` (BFF) green.
- `npm run build` (node:22, strict `tsc -b`) green.

Note: the demo `helloworld-go` function exposes no spec, so it'll show the free-form fallback; a function publishing OpenAPI gets the full dropdown experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)