### PR TITLE
feat(console): probe /spec.json for function route discovery

### DIFF
--- a/console-api/cmd/server/services.go
+++ b/console-api/cmd/server/services.go
@@ -405,6 +405,7 @@ func handleFunctionRoutes(cs kubernetes.Interface, logger *slog.Logger) http.Han
 	specLocations := []string{
 		"/openapi.json", "/swagger.json", "/v3/api-docs",
 		"/q/openapi.json", "/swagger/v1/swagger.json", "/openapi",
+		"/spec.json", // Swagger 2.0 (e.g. httpbin) — parsed the same way (.paths)
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		ns := chi.URLParam(r, "namespace")


### PR DESCRIPTION
Adds `/spec.json` to the function OpenAPI-discovery probe list so **Swagger 2.0** services (e.g. `httpbin`) are picked up. Swagger 2.0 uses the same top-level `paths{method}` structure, so it parses with the existing code — no parser change.

This lets the demo `demo-fn` (now `kennethreitz/httpbin`, which serves `/spec.json`) demonstrate route + method discovery in the test bench.

Verified httpbin serves `/spec.json` (HTTP 200, routes `/get` GET-only, `/post` POST-only, `/anything` all verbs) in-cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)