### PR TITLE
feat(console): Network observability view

### DIFF
--- a/platform/console/manifests/rbac.yaml
+++ b/platform/console/manifests/rbac.yaml
@@ -38,6 +38,14 @@ rules:
       - daemonsets
     verbs: [get, list, watch]
 
+  # ── Networking: read ingress routes + network policies (the Network view).
+  #    LoadBalancer Services come from the core "services" rule above. ─────────
+  - apiGroups: [networking.k8s.io]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: [get, list, watch]
+
   # ── Secrets: read by name only (no list/watch, so the console can't enumerate
   #    all secrets). Used to surface connection info — a Model's API key for the
   #    in-console playground, a Database's connection URI. ─────────────────────

--- a/ui/src/components/common/resource-table.tsx
+++ b/ui/src/components/common/resource-table.tsx
@@ -30,6 +30,8 @@ export interface ResourceTableConfig<T extends K8sObject> {
   deletePath?: (item: T) => string;
   /** Strings used for the global search filter. */
   searchFields: (item: T) => Array<string | undefined>;
+  /** Optional predicate to narrow the list (e.g. only LoadBalancer Services). */
+  filter?: (item: T) => boolean;
   /** Default sort. */
   defaultSort?: SortingState;
   emptyTitle?: string;
@@ -48,8 +50,11 @@ export function ResourceTable<T extends K8sObject>({
   config: ResourceTableConfig<T>;
   className?: string;
 }) {
-  const { items, isLoading, isError, error, live, refetch } = useK8sWatch<T>(
-    config.listPath,
+  const { items: allItems, isLoading, isError, error, live, refetch } =
+    useK8sWatch<T>(config.listPath);
+  const items = useMemo(
+    () => (config.filter ? allItems.filter(config.filter) : allItems),
+    [allItems, config],
   );
   const { filtered } = useListFilter(items, config.searchFields);
 

--- a/ui/src/components/layout/breadcrumbs.tsx
+++ b/ui/src/components/layout/breadcrumbs.tsx
@@ -8,6 +8,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   applications: "Applications",
   workloads: "Workloads",
   nodes: "Nodes",
+  network: "Network",
   monitoring: "Monitoring",
 };
 

--- a/ui/src/components/layout/nav-items.ts
+++ b/ui/src/components/layout/nav-items.ts
@@ -2,6 +2,7 @@ import {
   BrainCircuit,
   Boxes,
   Database,
+  Globe,
   HardDrive,
   LayoutDashboard,
   LineChart,
@@ -37,6 +38,7 @@ export const NAV_ITEMS: NavItem[] = [
 
   { label: "Workloads", to: "/workloads", icon: Network, matchPrefix: true, section: "Cluster" },
   { label: "Nodes", to: "/nodes", icon: Server, matchPrefix: true, section: "Cluster" },
+  { label: "Network", to: "/network", icon: Globe, matchPrefix: true, section: "Cluster" },
 
   { label: "Monitoring", to: "/monitoring", icon: LineChart, section: "Observability" },
 ];

--- a/ui/src/features/network/columns.tsx
+++ b/ui/src/features/network/columns.tsx
@@ -1,0 +1,218 @@
+import { type ColumnDef } from "@tanstack/react-table";
+import { Badge } from "@/components/ui/badge";
+import { age } from "@/lib/format";
+import type { Ingress, NetworkPolicy, Service } from "@/types/k8s";
+
+function nameCol<T extends { metadata: { name: string } }>(): ColumnDef<
+  T,
+  unknown
+> {
+  return {
+    id: "name",
+    header: "Name",
+    accessorFn: (r) => r.metadata.name,
+    cell: ({ row }) => (
+      <span className="font-medium">{row.original.metadata.name}</span>
+    ),
+    size: 220,
+  };
+}
+
+function namespaceCol<T extends { metadata: { namespace?: string } }>(): ColumnDef<
+  T,
+  unknown
+> {
+  return {
+    id: "namespace",
+    header: "Namespace",
+    accessorFn: (r) => r.metadata.namespace ?? "",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">
+        {row.original.metadata.namespace}
+      </span>
+    ),
+    size: 140,
+  };
+}
+
+function ageCol<T extends { metadata: { creationTimestamp?: string } }>(): ColumnDef<
+  T,
+  unknown
+> {
+  return {
+    id: "age",
+    header: "Age",
+    accessorFn: (r) => r.metadata.creationTimestamp ?? "",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">
+        {age(row.original.metadata.creationTimestamp)}
+      </span>
+    ),
+    size: 80,
+  };
+}
+
+/* ----------------------- Load Balancers (Services) ----------------------- */
+
+export function lbExternalIPs(s: Service): string[] {
+  return (s.status?.loadBalancer?.ingress ?? [])
+    .map((i) => i.ip || i.hostname)
+    .filter((v): v is string => Boolean(v));
+}
+
+function svcPorts(s: Service): string {
+  const ports = s.spec?.ports ?? [];
+  if (!ports.length) return "—";
+  return ports
+    .map((p) => `${p.port}/${p.protocol ?? "TCP"}`)
+    .join(", ");
+}
+
+export const loadBalancerColumns: ColumnDef<Service, unknown>[] = [
+  nameCol<Service>(),
+  namespaceCol<Service>(),
+  {
+    id: "externalIP",
+    header: "External IP (MetalLB)",
+    accessorFn: (s) => lbExternalIPs(s).join(", "),
+    cell: ({ row }) => {
+      const ips = lbExternalIPs(row.original);
+      return ips.length ? (
+        <code className="text-xs text-primary">{ips.join(", ")}</code>
+      ) : (
+        <span className="text-warning text-xs">pending</span>
+      );
+    },
+    size: 200,
+  },
+  {
+    id: "ports",
+    header: "Ports",
+    accessorFn: (s) => svcPorts(s),
+    cell: ({ row }) => (
+      <code className="text-xs">{svcPorts(row.original)}</code>
+    ),
+    size: 160,
+  },
+  ageCol<Service>(),
+];
+
+/* ------------------------------ Ingresses ------------------------------ */
+
+function ingressHosts(i: Ingress): string[] {
+  return (i.spec?.rules ?? [])
+    .map((r) => r.host)
+    .filter((h): h is string => Boolean(h));
+}
+
+function ingressAddress(i: Ingress): string {
+  const addrs = (i.status?.loadBalancer?.ingress ?? [])
+    .map((x) => x.ip || x.hostname)
+    .filter(Boolean);
+  return addrs.length ? addrs.join(", ") : "—";
+}
+
+export const ingressColumns: ColumnDef<Ingress, unknown>[] = [
+  nameCol<Ingress>(),
+  namespaceCol<Ingress>(),
+  {
+    id: "hosts",
+    header: "Hosts",
+    accessorFn: (i) => ingressHosts(i).join(", "),
+    cell: ({ row }) => {
+      const hosts = ingressHosts(row.original);
+      return hosts.length ? (
+        <span className="flex flex-col gap-0.5">
+          {hosts.map((h) => (
+            <code key={h} className="text-xs">
+              {h}
+            </code>
+          ))}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      );
+    },
+    size: 260,
+  },
+  {
+    id: "address",
+    header: "Address",
+    accessorFn: (i) => ingressAddress(i),
+    cell: ({ row }) => (
+      <code className="text-xs text-muted-foreground">
+        {ingressAddress(row.original)}
+      </code>
+    ),
+    size: 150,
+  },
+  {
+    id: "tls",
+    header: "TLS",
+    accessorFn: (i) => ((i.spec?.tls?.length ?? 0) > 0 ? "yes" : "no"),
+    cell: ({ row }) =>
+      (row.original.spec?.tls?.length ?? 0) > 0 ? (
+        <Badge variant="secondary">TLS</Badge>
+      ) : (
+        <span className="text-muted-foreground text-xs">—</span>
+      ),
+    size: 80,
+  },
+  {
+    id: "class",
+    header: "Class",
+    accessorFn: (i) => i.spec?.ingressClassName ?? "",
+    cell: ({ row }) => (
+      <span className="text-xs text-muted-foreground">
+        {row.original.spec?.ingressClassName ?? "—"}
+      </span>
+    ),
+    size: 110,
+  },
+  ageCol<Ingress>(),
+];
+
+/* --------------------------- Network Policies --------------------------- */
+
+function netpolSelector(np: NetworkPolicy): string {
+  const labels = np.spec?.podSelector?.matchLabels;
+  if (!labels || Object.keys(labels).length === 0) return "all pods";
+  return Object.entries(labels)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ");
+}
+
+export const networkPolicyColumns: ColumnDef<NetworkPolicy, unknown>[] = [
+  nameCol<NetworkPolicy>(),
+  namespaceCol<NetworkPolicy>(),
+  {
+    id: "selector",
+    header: "Applies to",
+    accessorFn: (np) => netpolSelector(np),
+    cell: ({ row }) => (
+      <code className="text-xs">{netpolSelector(row.original)}</code>
+    ),
+    size: 240,
+  },
+  {
+    id: "types",
+    header: "Policy types",
+    accessorFn: (np) => (np.spec?.policyTypes ?? []).join(", "),
+    cell: ({ row }) => {
+      const types = row.original.spec?.policyTypes ?? [];
+      return types.length ? (
+        <span className="flex gap-1">
+          {types.map((t) => (
+            <Badge key={t} variant="secondary">
+              {t}
+            </Badge>
+          ))}
+        </span>
+      ) : (
+        <span className="text-muted-foreground text-xs">—</span>
+      );
+    },
+    size: 180,
+  },
+  ageCol<NetworkPolicy>(),
+];

--- a/ui/src/features/network/network-page.tsx
+++ b/ui/src/features/network/network-page.tsx
@@ -1,0 +1,80 @@
+import { Globe } from "lucide-react";
+import { PageHeader } from "@/components/common/page-header";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  ResourceTable,
+  type ResourceTableConfig,
+} from "@/components/common/resource-table";
+import {
+  ingressColumns,
+  loadBalancerColumns,
+  networkPolicyColumns,
+} from "@/features/network/columns";
+import { corePaths, networkingPaths } from "@/lib/k8s-paths";
+import { useNamespace } from "@/lib/namespace-context";
+import type { Ingress, NetworkPolicy, Service } from "@/types/k8s";
+
+export function NetworkPage() {
+  const { scoped } = useNamespace();
+
+  const lbConfig: ResourceTableConfig<Service> = {
+    kind: "Load Balancer",
+    listPath: corePaths.services(scoped),
+    columns: loadBalancerColumns,
+    filter: (s) => s.spec?.type === "LoadBalancer",
+    searchFields: (s) => [s.metadata.name, s.metadata.namespace],
+    emptyTitle: "No Load Balancers",
+    emptyDescription:
+      "No LoadBalancer Services in this scope. MetalLB assigns an external IP to each one.",
+  };
+
+  const ingressConfig: ResourceTableConfig<Ingress> = {
+    kind: "Ingress",
+    listPath: networkingPaths.ingresses(scoped),
+    columns: ingressColumns,
+    searchFields: (i) => [
+      i.metadata.name,
+      i.metadata.namespace,
+      ...(i.spec?.rules?.map((r) => r.host) ?? []),
+    ],
+    emptyTitle: "No Ingresses",
+    emptyDescription: "No Ingress routes (Traefik) in this scope.",
+  };
+
+  const netpolConfig: ResourceTableConfig<NetworkPolicy> = {
+    kind: "Network Policy",
+    listPath: networkingPaths.networkPolicies(scoped),
+    columns: networkPolicyColumns,
+    searchFields: (np) => [np.metadata.name, np.metadata.namespace],
+    emptyTitle: "No Network Policies",
+    emptyDescription:
+      "No NetworkPolicies in this scope. Each app namespace gets one for tenant isolation.",
+  };
+
+  return (
+    <div className="space-y-5">
+      <PageHeader
+        icon={<Globe />}
+        title="Network"
+        description="Load balancers (MetalLB), ingress routes (Traefik + TLS), and network policies."
+      />
+
+      <Tabs defaultValue="loadbalancers">
+        <TabsList>
+          <TabsTrigger value="loadbalancers">Load Balancers</TabsTrigger>
+          <TabsTrigger value="ingresses">Ingresses</TabsTrigger>
+          <TabsTrigger value="policies">Network Policies</TabsTrigger>
+        </TabsList>
+        <TabsContent value="loadbalancers">
+          <ResourceTable config={lbConfig} />
+        </TabsContent>
+        <TabsContent value="ingresses">
+          <ResourceTable config={ingressConfig} />
+        </TabsContent>
+        <TabsContent value="policies">
+          <ResourceTable config={netpolConfig} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/ui/src/lib/k8s-paths.ts
+++ b/ui/src/lib/k8s-paths.ts
@@ -30,6 +30,13 @@ export const appsPaths = {
   deployments: (ns?: string) => `/apis/apps/v1${nsSegment(ns)}/deployments`,
 };
 
+export const networkingPaths = {
+  ingresses: (ns?: string) =>
+    `/apis/networking.k8s.io/v1${nsSegment(ns)}/ingresses`,
+  networkPolicies: (ns?: string) =>
+    `/apis/networking.k8s.io/v1${nsSegment(ns)}/networkpolicies`,
+};
+
 const oiGV = `/apis/${OPENINFRA_GROUP}/${OPENINFRA_VERSION}`;
 
 export const openinfraPaths = {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -20,6 +20,7 @@ import { BucketDetailPage } from "@/features/buckets/bucket-detail-page";
 import { QueuesPage } from "@/features/queues/queues-page";
 import { WorkloadsPage } from "@/features/workloads/workloads-page";
 import { NodesPage } from "@/features/nodes/nodes-page";
+import { NetworkPage } from "@/features/network/network-page";
 import { MonitoringPage } from "@/features/monitoring/monitoring-page";
 
 const rootRoute = createRootRoute({
@@ -112,6 +113,12 @@ const nodesRoute = createRoute({
   component: NodesPage,
 });
 
+const networkRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/network",
+  component: NetworkPage,
+});
+
 const monitoringRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/monitoring",
@@ -133,6 +140,7 @@ const routeTree = rootRoute.addChildren([
   queueDetailRoute,
   workloadsRoute,
   nodesRoute,
+  networkRoute,
   monitoringRoute,
 ]);
 

--- a/ui/src/types/k8s.ts
+++ b/ui/src/types/k8s.ts
@@ -120,6 +120,35 @@ export interface ServiceStatus {
 
 export type Service = K8sObject<ServiceSpec, ServiceStatus>;
 
+/* ------------------------------ Networking ------------------------------ */
+
+export interface IngressSpec {
+  ingressClassName?: string;
+  rules?: {
+    host?: string;
+    http?: {
+      paths?: {
+        path?: string;
+        pathType?: string;
+        backend?: { service?: { name?: string; port?: { number?: number } } };
+      }[];
+    };
+  }[];
+  tls?: { hosts?: string[]; secretName?: string }[];
+}
+export interface IngressStatus {
+  loadBalancer?: { ingress?: { ip?: string; hostname?: string }[] };
+}
+export type Ingress = K8sObject<IngressSpec, IngressStatus>;
+
+export interface NetworkPolicySpec {
+  podSelector?: { matchLabels?: Record<string, string> };
+  policyTypes?: string[];
+  ingress?: unknown[];
+  egress?: unknown[];
+}
+export type NetworkPolicy = K8sObject<NetworkPolicySpec, unknown>;
+
 export interface NodeSpec {
   podCIDR?: string;
   taints?: { key: string; value?: string; effect: string }[];


### PR DESCRIPTION
## What

Closes #6 — the console had no networking view. Adds a **Network** page (Cluster section) with three tabs:

- **Load Balancers** — `LoadBalancer` Services with their **MetalLB-assigned external IPs** + ports.
- **Ingresses** — Traefik routes: hosts, address, **TLS**, ingress class.
- **Network Policies** — per-namespace isolation: which pods they apply to, policy types.

## How

- New `features/network/` (columns + tabbed page), mirroring the Workloads page; each tab reuses the live `ResourceTable` (search, View YAML, live updates) — read-only.
- `ResourceTableConfig` gains an optional `filter` predicate (used to show only `LoadBalancer` Services from the Services list).
- New types (`Ingress`, `NetworkPolicy`), `networkingPaths`, route, nav item (Globe icon), breadcrumb.
- **RBAC**: grant the console SA `get/list/watch` on `networking.k8s.io` `ingresses` + `networkpolicies` (it already had core `services`).

## Testing

- `tsc --noEmit` + `npm run build` (node:22) green.
- `kubectl apply --dry-run=server` validates the RBAC.
- Confirmed the SA *currently* can't list ingresses/networkpolicies (403) — this PR's RBAC fixes that; Argo applies it on merge.

Note: needs both the new image (rollout) **and** the RBAC (Argo sync) to be live.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)