### PR TITLE
feat(db): NoSQL document database via FerretDB (engine: mongo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ CNCF projects — not a reinvention of databases or storage.
 | ACM | TLS | cert-manager |
 | S3 | object storage | MinIO |
 | RDS | managed Postgres | CloudNativePG |
+| DynamoDB | document store (`engine: mongo`) | FerretDB on DocumentDB-Postgres |
 | SQS / SNS | queues + pub/sub | NATS JetStream |
 | ElastiCache | cache | Redis |
 | Lambda | serverless (`kind: Function`) | Knative — scale-to-zero |

--- a/cli/open-infra
+++ b/cli/open-infra
@@ -29,6 +29,7 @@ spec:
   scaling: { min: 1, max: 5, targetCPUPercent: 70 }
   domain: ${name}.example            # dev mode rewrites this to sslip.io
   # database: { engine: postgres, name: ${name}db }   # +highAvailability: true for failover
+  #   engine: mongo -> document store (FerretDB), injects MONGODB_URI instead of DATABASE_URL
   # storage:  { buckets: [uploads] }
   # queues:   [jobs]
   # secrets:  [chat-model]           # inject a Model endpoint (see: init model)

--- a/examples/hello-web/infra.yaml
+++ b/examples/hello-web/infra.yaml
@@ -12,6 +12,7 @@ spec:
   # Uncomment any of these — the platform provisions them and injects creds:
   # database: { engine: postgres, name: hellodb }   # -> DATABASE_URL
   #   add highAvailability: true -> primary + standby on separate nodes, auto-failover
+  #   or engine: mongo  -> document store (FerretDB), injects MONGODB_URI
   # storage:  { buckets: [uploads] }                # -> MINIO_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKETS
   # queues:   [jobs]                                # -> NATS_URL, OPENINFRA_QUEUES
   # secrets:  [hello-extra]                         # -> envFrom that secret (e.g. a Sealed Secret)

--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -3,7 +3,8 @@
 # Pipeline mode with the go-templating function keeps the fan-out readable.
 #
 # Implements the full user-facing schema (xrd.yaml):
-#   database        -> CloudNativePG Cluster + injected DATABASE_URL
+#   database (postgres) -> CloudNativePG Cluster + injected DATABASE_URL
+#   database (mongo)    -> FerretDB + DocumentDB-Postgres + injected MONGODB_URI
 #   storage.buckets -> MinIO bucket(s) + per-app creds (MINIO_*) via a setup Job
 #   queues          -> injected NATS_URL + OPENINFRA_QUEUES (streams app-declared)
 #   secrets         -> envFrom each named secret
@@ -36,6 +37,14 @@ spec:
             {{- $name := (index $labels "crossplane.io/claim-name") | default .observed.composite.resource.metadata.name }}
             {{- $ns := (index $labels "crossplane.io/claim-namespace") | default "default" }}
             {{- $scaling := $spec.scaling | default dict }}
+            {{- /* database.engine: postgres (CloudNativePG) or mongo (FerretDB on
+                   the DocumentDB-Postgres extension). dbPass is derived from the
+                   composite UID so it's stable across reconciles (never committed). */}}
+            {{- $dbEngine := "" }}
+            {{- if $spec.database }}{{ $dbEngine = ($spec.database.engine | default "postgres") }}{{- end }}
+            {{- $dbName := "" }}
+            {{- if $spec.database }}{{ $dbName = ($spec.database.name | default $name) }}{{- end }}
+            {{- $dbPass := .observed.composite.resource.metadata.uid | sha256sum | trunc 24 }}
             ---
             # --- Deployment ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
@@ -74,10 +83,17 @@ spec:
                               - { name: {{ .name }}, value: "{{ .value }}" }
                             {{- end }}
                             {{- if $spec.database }}
+                            {{- if eq $dbEngine "mongo" }}
+                              # Injected MongoDB connection (FerretDB endpoint).
+                              - name: MONGODB_URI
+                                valueFrom:
+                                  secretKeyRef: { name: {{ $name }}-mongo-app, key: MONGODB_URI }
+                            {{- else }}
                               # Injected Postgres connection (CloudNativePG app secret).
                               - name: DATABASE_URL
                                 valueFrom:
                                   secretKeyRef: { name: {{ $name }}-db-app, key: uri }
+                            {{- end }}
                             {{- end }}
                             {{- if $spec.queues }}
                               - { name: NATS_URL, value: "nats://nats.nats.svc.cluster.local:4222" }
@@ -233,6 +249,158 @@ spec:
                           - namespaceSelector:
                               matchLabels: { kubernetes.io/metadata.name: kube-system }
             {{- if $spec.database }}
+            {{- if eq $dbEngine "mongo" }}
+            ---
+            # --- NoSQL ("DynamoDB"): FerretDB (Mongo wire protocol) on the
+            #     DocumentDB-Postgres extension — all Apache-2.0. The stateless
+            #     proxy tier scales out for HA; storage is a single Postgres for
+            #     now (storage-tier failover needs DocumentDB-in-CNPG, tracked). ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: mongo-secret
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Secret
+                  metadata: { name: {{ $name }}-mongo-app, namespace: {{ $ns }} }
+                  stringData:
+                    username: app
+                    password: "{{ $dbPass }}"
+                    MONGODB_URI: "mongodb://app:{{ $dbPass }}@{{ $name }}-mongo.{{ $ns }}.svc.cluster.local:27017/{{ $dbName }}"
+                    POSTGRESQL_URL: "postgres://app:{{ $dbPass }}@{{ $name }}-docdb.{{ $ns }}.svc.cluster.local:5432/postgres"
+            ---
+            # DocumentDB-Postgres data volume (local NVMe).
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: docdb-pvc
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: PersistentVolumeClaim
+                  metadata: { name: {{ $name }}-docdb-data, namespace: {{ $ns }} }
+                  spec:
+                    accessModes: [ReadWriteOnce]
+                    storageClassName: local-path
+                    resources: { requests: { storage: 5Gi } }
+            ---
+            # DocumentDB-Postgres: the storage engine FerretDB translates into.
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: docdb
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  metadata:
+                    name: {{ $name }}-docdb
+                    namespace: {{ $ns }}
+                    labels: { app.kubernetes.io/name: {{ $name }}-docdb }
+                  spec:
+                    replicas: 1
+                    strategy: { type: Recreate }
+                    selector: { matchLabels: { app.kubernetes.io/name: {{ $name }}-docdb } }
+                    template:
+                      metadata: { labels: { app.kubernetes.io/name: {{ $name }}-docdb } }
+                      spec:
+                        containers:
+                          - name: postgres
+                            image: ghcr.io/ferretdb/postgres-documentdb:17
+                            env:
+                              - { name: POSTGRES_USER, value: app }
+                              - { name: POSTGRES_DB, value: postgres }
+                              - name: POSTGRES_PASSWORD
+                                valueFrom: { secretKeyRef: { name: {{ $name }}-mongo-app, key: password } }
+                            ports: [ { containerPort: 5432 } ]
+                            resources:
+                              requests: { cpu: 100m, memory: 256Mi }
+                              limits: { cpu: "2", memory: 2Gi }
+                            volumeMounts: [ { name: data, mountPath: /var/lib/postgresql/data } ]
+                            readinessProbe: { exec: { command: ["pg_isready", "-U", "app"] }, initialDelaySeconds: 10, periodSeconds: 10 }
+                        volumes:
+                          - name: data
+                            persistentVolumeClaim: { claimName: {{ $name }}-docdb-data }
+            ---
+            # DocumentDB-Postgres Service.
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: docdb-svc
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Service
+                  metadata: { name: {{ $name }}-docdb, namespace: {{ $ns }} }
+                  spec:
+                    selector: { app.kubernetes.io/name: {{ $name }}-docdb }
+                    ports: [ { port: 5432, targetPort: 5432 } ]
+            ---
+            # FerretDB proxy (stateless -> scales for HA). Speaks the Mongo protocol.
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: mongo
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  metadata:
+                    name: {{ $name }}-mongo
+                    namespace: {{ $ns }}
+                    labels: { app.kubernetes.io/name: {{ $name }}-mongo }
+                  spec:
+                    replicas: {{ if $spec.database.highAvailability }}2{{ else }}1{{ end }}
+                    selector: { matchLabels: { app.kubernetes.io/name: {{ $name }}-mongo } }
+                    template:
+                      metadata: { labels: { app.kubernetes.io/name: {{ $name }}-mongo } }
+                      spec:
+                        {{- if $spec.database.highAvailability }}
+                        affinity:
+                          podAntiAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              - labelSelector: { matchLabels: { app.kubernetes.io/name: {{ $name }}-mongo } }
+                                topologyKey: kubernetes.io/hostname
+                        {{- end }}
+                        containers:
+                          - name: ferretdb
+                            image: ghcr.io/ferretdb/ferretdb:2
+                            env:
+                              - name: FERRETDB_POSTGRESQL_URL
+                                valueFrom: { secretKeyRef: { name: {{ $name }}-mongo-app, key: POSTGRESQL_URL } }
+                            ports: [ { containerPort: 27017 } ]
+                            resources:
+                              requests: { cpu: 50m, memory: 128Mi }
+                              limits: { cpu: "1", memory: 512Mi }
+                            readinessProbe: { tcpSocket: { port: 27017 }, initialDelaySeconds: 5, periodSeconds: 10 }
+            ---
+            # FerretDB Service — the Mongo endpoint apps connect to (27017).
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: mongo-svc
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Service
+                  metadata: { name: {{ $name }}-mongo, namespace: {{ $ns }} }
+                  spec:
+                    selector: { app.kubernetes.io/name: {{ $name }}-mongo }
+                    ports: [ { port: 27017, targetPort: 27017 } ]
+            {{- else }}
             ---
             # --- Managed Postgres ("RDS") via CloudNativePG. LOCAL NVMe only. ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
@@ -263,6 +431,7 @@ spec:
                       storageClass: local-path   # NEVER CIFS/NFS
                     bootstrap:
                       initdb: { database: {{ $spec.database.name | default $name }}, owner: app }
+            {{- end }}
             {{- end }}
             {{- if and $spec.storage $spec.storage.buckets }}
             ---

--- a/platform/abstraction/xrd.yaml
+++ b/platform/abstraction/xrd.yaml
@@ -47,11 +47,15 @@ spec:
                 database:
                   type: object
                   properties:
-                    engine: { type: string, enum: [postgres], default: postgres }
+                    # postgres -> CloudNativePG (relational, injects DATABASE_URL).
+                    # mongo    -> FerretDB on DocumentDB-Postgres (document store,
+                    #             Mongo wire protocol, injects MONGODB_URI). Apache-2.0.
+                    engine: { type: string, enum: [postgres, mongo], default: postgres }
                     name:   { type: string }
-                    # Run a primary + standby on separate nodes with automatic
-                    # failover (CloudNativePG). Survives a node loss; needs >=2
-                    # nodes. Default false = single instance (fine for dev).
+                    # postgres: primary + standby on separate nodes with automatic
+                    # failover (CloudNativePG). mongo: scales the stateless FerretDB
+                    # proxy tier (storage-tier failover is a tracked follow-up).
+                    # Needs >=2 nodes. Default false = single instance (fine for dev).
                     highAvailability: { type: boolean, default: false }
                 storage:
                   type: object

--- a/ui/src/components/common/resource-table-page.tsx
+++ b/ui/src/components/common/resource-table-page.tsx
@@ -24,6 +24,8 @@ export interface ResourceTablePageProps<T extends K8sObject> {
   listPath: (ns?: string) => string;
   columns: ColumnDef<T, unknown>[];
   search: (item: T) => (string | undefined)[];
+  /** Optional predicate to narrow the list (e.g. only Apps with a database). */
+  filter?: (item: T) => boolean;
   singular: string;
   plural: string;
   emptyTitle: string;
@@ -47,6 +49,7 @@ export function ResourceTablePage<T extends K8sObject>({
   listPath,
   columns,
   search,
+  filter,
   singular,
   plural,
   emptyTitle,
@@ -55,9 +58,9 @@ export function ResourceTablePage<T extends K8sObject>({
   headerActions,
 }: ResourceTablePageProps<T>) {
   const { scoped } = useNamespace();
-  const { items, isLoading, isError, error, live, refetch } = useK8sWatch<T>(
-    listPath(scoped),
-  );
+  const { items: allItems, isLoading, isError, error, live, refetch } =
+    useK8sWatch<T>(listPath(scoped));
+  const items = filter ? allItems.filter(filter) : allItems;
   const { filtered } = useListFilter(items, search);
   const [sorting, setSorting] = useState<SortingState>([
     { id: "name", desc: false },

--- a/ui/src/features/databases/databases-page.tsx
+++ b/ui/src/features/databases/databases-page.tsx
@@ -3,89 +3,94 @@ import { type ColumnDef } from "@tanstack/react-table";
 import { useNavigate } from "@tanstack/react-router";
 import { Database } from "lucide-react";
 import { StatusBadge } from "@/components/common/status-badge";
+import { Badge } from "@/components/ui/badge";
 import { ResourceTablePage } from "@/components/common/resource-table-page";
-import { cnpgPaths } from "@/lib/k8s-paths";
-import { age, type StatusTone } from "@/lib/format";
-import type { CnpgCluster } from "@/types/k8s";
+import { claimHealth } from "@/lib/resource-health";
+import { openinfraPaths } from "@/lib/k8s-paths";
+import { age } from "@/lib/format";
+import type { Application } from "@/types/k8s";
 
-/** CloudNativePG reports a free-text status.phase ("Cluster in healthy state", …). */
-function dbTone(phase?: string): StatusTone {
-  if (!phase) return "muted";
-  const p = phase.toLowerCase();
-  if (p.includes("healthy")) return "success";
-  if (p.includes("fail") || p.includes("unhealth") || p.includes("error")) {
-    return "destructive";
-  }
-  return "warning";
+/** Databases are provisioned by an Application's `database:` block — postgres
+ *  (CloudNativePG) or mongo (FerretDB). We list them from their owning
+ *  Application so both engines appear with the engine they use. */
+function engineLabel(engine?: string): string {
+  return engine === "mongo" ? "MongoDB (FerretDB)" : "PostgreSQL";
 }
 
 export function DatabasesPage() {
   const navigate = useNavigate();
-  const columns = useMemo<ColumnDef<CnpgCluster, unknown>[]>(
+  const columns = useMemo<ColumnDef<Application, unknown>[]>(
     () => [
       {
         id: "name",
         header: "Name",
-        accessorFn: (c) => c.metadata.name,
+        accessorFn: (a) => a.spec?.database?.name ?? a.metadata.name,
         cell: ({ row }) => (
-          <span className="font-medium">{row.original.metadata.name}</span>
+          <span className="font-medium">
+            {row.original.spec?.database?.name ?? row.original.metadata.name}
+          </span>
         ),
-        size: 220,
+        size: 190,
       },
       {
         id: "namespace",
         header: "Namespace",
-        accessorFn: (c) => c.metadata.namespace,
+        accessorFn: (a) => a.metadata.namespace,
         cell: ({ row }) => (
           <span className="text-muted-foreground">
             {row.original.metadata.namespace}
           </span>
         ),
-        size: 140,
+        size: 130,
       },
       {
-        id: "instances",
-        header: "Instances",
-        accessorFn: (c) => c.status?.readyInstances ?? 0,
-        cell: ({ row }) => {
-          const s = row.original;
-          const ready = s.status?.readyInstances ?? 0;
-          const total = s.spec?.instances ?? s.status?.instances ?? 1;
-          return (
-            <span className="text-xs text-muted-foreground">
-              {ready}/{total} ready
-            </span>
-          );
-        },
-        size: 120,
+        id: "engine",
+        header: "Engine",
+        accessorFn: (a) => engineLabel(a.spec?.database?.engine),
+        cell: ({ row }) => (
+          <Badge variant="secondary">
+            {engineLabel(row.original.spec?.database?.engine)}
+          </Badge>
+        ),
+        size: 170,
       },
       {
-        id: "storage",
-        header: "Storage",
-        accessorFn: (c) => c.spec?.storage?.size ?? "",
+        id: "ha",
+        header: "HA",
+        accessorFn: (a) => (a.spec?.database?.highAvailability ? "yes" : "no"),
+        cell: ({ row }) =>
+          row.original.spec?.database?.highAvailability ? (
+            <Badge variant="secondary">HA</Badge>
+          ) : (
+            <span className="text-xs text-muted-foreground">—</span>
+          ),
+        size: 70,
+      },
+      {
+        id: "app",
+        header: "Application",
+        accessorFn: (a) => a.metadata.name,
         cell: ({ row }) => (
           <span className="text-xs text-muted-foreground">
-            {row.original.spec?.storage?.size ?? "—"}
+            {row.original.metadata.name}
           </span>
         ),
-        size: 100,
+        size: 150,
       },
       {
         id: "status",
         header: "Status",
-        accessorFn: (c) => c.status?.phase ?? "",
+        accessorFn: (a) => claimHealth(a).label,
         cell: ({ row }) => {
-          const phase = row.original.status?.phase;
-          return (
-            <StatusBadge status={phase ?? "Pending"} tone={dbTone(phase)} />
-          );
+          const h = claimHealth(row.original);
+          return <StatusBadge status={h.label} tone={h.tone} />;
         },
-        size: 220,
+        size: 150,
       },
       {
         id: "age",
         header: "Age",
-        accessorFn: (c) => c.metadata.creationTimestamp ?? "",
+        accessorFn: (a) => a.metadata.creationTimestamp ?? "",
         cell: ({ row }) => (
           <span className="text-muted-foreground">
             {age(row.original.metadata.creationTimestamp)}
@@ -98,26 +103,36 @@ export function DatabasesPage() {
   );
 
   return (
-    <ResourceTablePage<CnpgCluster>
+    <ResourceTablePage<Application>
       icon={<Database />}
       title="Databases"
-      description="Managed PostgreSQL — open-infra's RDS (CloudNativePG). Provisioned by an Application's `database:` block."
-      listPath={cnpgPaths.clusters}
+      description="Managed databases — open-infra's RDS. Provisioned by an Application's `database:` block: postgres (CloudNativePG) or mongo (FerretDB)."
+      listPath={openinfraPaths.applications}
       columns={columns}
-      search={(c) => [c.metadata.name, c.metadata.namespace, c.status?.phase]}
+      filter={(a) => Boolean(a.spec?.database)}
+      search={(a) => [
+        a.metadata.name,
+        a.metadata.namespace,
+        a.spec?.database?.name,
+        a.spec?.database?.engine,
+      ]}
       singular="Database"
       plural="Databases"
       emptyTitle="No Databases yet"
-      emptyDescription="Add `database: { engine: postgres }` to an Application and the platform provisions a Postgres cluster here."
-      onRowClick={(c) =>
-        navigate({
-          to: "/databases/$namespace/$name",
-          params: {
-            namespace: c.metadata.namespace ?? "default",
-            name: c.metadata.name ?? "",
-          },
-        })
-      }
+      emptyDescription="Add a `database:` block to an Application (engine: postgres or mongo) and it appears here."
+      onRowClick={(a) => {
+        // Postgres has a rich CloudNativePG detail page (cluster <app>-db).
+        // Mongo (FerretDB) has no detail page yet — clicking is a no-op for now.
+        if ((a.spec?.database?.engine ?? "postgres") !== "mongo") {
+          navigate({
+            to: "/databases/$namespace/$name",
+            params: {
+              namespace: a.metadata.namespace ?? "default",
+              name: `${a.metadata.name}-db`,
+            },
+          });
+        }
+      }}
     />
   );
 }

--- a/ui/src/types/k8s.ts
+++ b/ui/src/types/k8s.ts
@@ -199,7 +199,7 @@ export interface ApplicationSpec {
     max?: number;
     targetCPUPercent?: number;
   };
-  database?: { engine?: string; name?: string };
+  database?: { engine?: string; name?: string; highAvailability?: boolean };
   storage?: { buckets?: string[] };
   queues?: string[];
   env?: { name: string; value: string }[];


### PR DESCRIPTION
## What

Closes #15 — a non-relational database option for apps that don't need Postgres:

```yaml
database:
  engine: mongo        # document store
  name: mydb
```

The app gets a **`MONGODB_URI`** injected and talks to it with any MongoDB driver.

## Why FerretDB (not MongoDB)

MongoDB Community is **SSPL** (source-available, not OSI open source). open-infra is Apache-2.0 and built on truly-open tooling, so we use **FerretDB** — Apache 2.0, speaks the **MongoDB wire protocol**, and stores data in **PostgreSQL via the DocumentDB extension**. No license compromise, and it reuses the Postgres tech we already run.

## How

- **XRD**: `database.engine` enum gains `mongo`.
- **Composition** (`engine: mongo`): renders FerretDB + DocumentDB-Postgres (PVC + Deployment + Service each) and a connection Secret; injects `MONGODB_URI` (vs `DATABASE_URL` for postgres). The DB password is derived from the composite UID — stable across reconciles, never committed.
- **HA**: `highAvailability` scales the **stateless FerretDB proxy tier** (2 replicas + anti-affinity). **Storage-tier failover** (Postgres) needs the DocumentDB extension inside CNPG — a tracked follow-up, documented honestly so the flag doesn't over-promise.
- **Console**: the Databases page now sources from the owning **Application**, so **both engines appear**, with a new **Engine** column (+ HA). `ResourceTablePage` gained an optional `filter`.
- **Docs**: README AWS mapping (DynamoDB row), example + CLI scaffolds.

## Testing

- **FerretDB verified end-to-end locally**: `mongosh` insert + `$gt` query through FerretDB → DocumentDB-Postgres returned correct results; confirmed env vars + connection string.
- **Composition rendered offline** with the real Sprig engine across `postgres` / `mongo` / `mongo+HA` / no-db — all produce valid, correctly-structured YAML (mongo path = 6 added resources).
- `kubectl apply --dry-run=server` validates XRD + Composition; `tsc` + `npm run build` (node:22) green.
- Image tags verified to exist (`ghcr.io/ferretdb/ferretdb:2`, `ghcr.io/ferretdb/postgres-documentdb:17`).

## Follow-ups (noted, not in scope)
- Storage-tier HA for mongo (DocumentDB-in-CNPG image).
- A FerretDB/mongo detail page in the console (postgres has the CNPG detail).

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)