### PR TITLE
feat(console): resource-scoped Grafana, FerretDB detail page, hand-roll DB

### DIFF
--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -45,6 +45,10 @@ spec:
             {{- $dbName := "" }}
             {{- if $spec.database }}{{ $dbName = ($spec.database.name | default $name) }}{{- end }}
             {{- $dbPass := .observed.composite.resource.metadata.uid | sha256sum | trunc 24 }}
+            {{- /* The workload (Deployment/Service/Ingress/HPA) renders only when an
+                   image is given. An Application may be database-only — just declare
+                   a `database:` block and the platform provisions the DB, no app. */}}
+            {{- if $spec.image }}
             ---
             # --- Deployment ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
@@ -177,6 +181,7 @@ spec:
                         resource:
                           name: cpu
                           target: { type: Utilization, averageUtilization: {{ $scaling.targetCPUPercent | default 70 }} }
+            {{- end }}
             ---
             # --- Tenant isolation: per-container defaults + max size (so the
             #     count quota below never rejects a pod for missing resources) ---

--- a/platform/abstraction/xrd.yaml
+++ b/platform/abstraction/xrd.yaml
@@ -33,9 +33,12 @@ spec:
           properties:
             spec:
               type: object
-              required: [image, port]
+              # No hard-required fields: an Application is usually image+port, but it
+              # may be "data-only" (just a database/storage/queues block) — e.g. a
+              # database hand-rolled from the console. The workload renders only when
+              # an image is set.
               properties:
-                image:   { type: string, description: "Container image (CI replaces the tag)" }
+                image:   { type: string, description: "Container image (omit for a data-only app)" }
                 port:    { type: integer, description: "Container port the app listens on" }
                 domain:  { type: string, description: "Hostname for Ingress + TLS + DNS" }
                 scaling:

--- a/platform/observability/app-overview-dashboard.yaml
+++ b/platform/observability/app-overview-dashboard.yaml
@@ -1,12 +1,13 @@
 # A default per-app dashboard: CPU + memory + a live log panel, parameterized by
-# namespace. Provisioned as a ConfigMap that the kube-prometheus-stack Grafana
-# sidecar (label grafana_dashboard=1) auto-imports — so every app gets metrics +
-# logs in one view with no per-app config. Importantly, it's a *dashboard* (not
-# Explore), so anonymous Viewers can see the logs in the embedded console.
+# namespace AND a `pod` regex. Provisioned as a ConfigMap that the
+# kube-prometheus-stack Grafana sidecar (label grafana_dashboard=1) auto-imports —
+# so every app gets metrics + logs in one view with no per-app config. It's a
+# *dashboard* (not Explore), so anonymous Viewers can see the logs in the embed.
 #
-# Note: in the console's full-kiosk embed the variable bar is hidden, so the
-# embed shows the default namespace; use "Open in Grafana" for the namespace
-# picker. (A console-side namespace selector can pass &var-namespace= later.)
+# The console scopes each resource's panel by passing &var-namespace=<ns> and
+# &var-pod=<name>-.* — so a Function/Database/Model detail shows only THAT
+# resource's pods, not everything in the namespace. `pod` defaults to ".*"
+# (all pods) when not supplied.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,6 +35,13 @@ data:
             "refresh": 2,
             "sort": 1,
             "includeAll": false
+          },
+          {
+            "name": "pod",
+            "label": "Pod (regex)",
+            "type": "textbox",
+            "query": ".*",
+            "current": { "text": ".*", "value": ".*" }
           }
         ]
       },
@@ -49,7 +57,7 @@ data:
             {
               "refId": "A",
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container!=\"\", pod!=\"\"}[5m])) by (pod)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", pod!=\"\"}[5m])) by (pod)",
               "legendFormat": "{{pod}}"
             }
           ]
@@ -65,7 +73,7 @@ data:
             {
               "refId": "A",
               "datasource": { "type": "prometheus", "uid": "prometheus" },
-              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", container!=\"\", pod!=\"\"}) by (pod)",
+              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", pod!=\"\"}) by (pod)",
               "legendFormat": "{{pod}}"
             }
           ]
@@ -87,7 +95,7 @@ data:
             {
               "refId": "A",
               "datasource": { "type": "loki", "uid": "loki" },
-              "expr": "{namespace=\"$namespace\"}",
+              "expr": "{namespace=\"$namespace\", pod=~\"$pod\"}",
               "queryType": "range"
             }
           ]

--- a/ui/src/features/databases/databases-page.tsx
+++ b/ui/src/features/databases/databases-page.tsx
@@ -1,14 +1,18 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { useNavigate } from "@tanstack/react-router";
-import { Database } from "lucide-react";
+import { Database, Plus } from "lucide-react";
 import { StatusBadge } from "@/components/common/status-badge";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { ResourceTablePage } from "@/components/common/resource-table-page";
+import { NewDatabaseDialog } from "@/features/databases/new-database-dialog";
 import { claimHealth } from "@/lib/resource-health";
-import { openinfraPaths } from "@/lib/k8s-paths";
+import { corePaths, openinfraPaths } from "@/lib/k8s-paths";
+import { useK8sWatch } from "@/hooks/use-k8s-watch";
+import { useNamespace } from "@/lib/namespace-context";
 import { age } from "@/lib/format";
-import type { Application } from "@/types/k8s";
+import type { Application, K8sObject } from "@/types/k8s";
 
 /** Databases are provisioned by an Application's `database:` block — postgres
  *  (CloudNativePG) or mongo (FerretDB). We list them from their owning
@@ -19,6 +23,13 @@ function engineLabel(engine?: string): string {
 
 export function DatabasesPage() {
   const navigate = useNavigate();
+  const { scoped } = useNamespace();
+  const [newOpen, setNewOpen] = useState(false);
+  const nsWatch = useK8sWatch<K8sObject>(corePaths.namespaces());
+  const namespaces = nsWatch.items
+    .map((n) => n.metadata.name)
+    .filter((n): n is string => Boolean(n))
+    .sort((a, b) => a.localeCompare(b));
   const columns = useMemo<ColumnDef<Application, unknown>[]>(
     () => [
       {
@@ -103,6 +114,7 @@ export function DatabasesPage() {
   );
 
   return (
+    <>
     <ResourceTablePage<Application>
       icon={<Database />}
       title="Databases"
@@ -119,20 +131,37 @@ export function DatabasesPage() {
       singular="Database"
       plural="Databases"
       emptyTitle="No Databases yet"
-      emptyDescription="Add a `database:` block to an Application (engine: postgres or mongo) and it appears here."
+      emptyDescription="Add a `database:` block to an Application (engine: postgres or mongo), or click New Database."
+      headerActions={
+        <Button onClick={() => setNewOpen(true)}>
+          <Plus className="size-4" />
+          New Database
+        </Button>
+      }
       onRowClick={(a) => {
-        // Postgres has a rich CloudNativePG detail page (cluster <app>-db).
-        // Mongo (FerretDB) has no detail page yet — clicking is a no-op for now.
-        if ((a.spec?.database?.engine ?? "postgres") !== "mongo") {
+        const ns = a.metadata.namespace ?? "default";
+        if ((a.spec?.database?.engine ?? "postgres") === "mongo") {
+          // FerretDB detail keys off the owning Application name.
+          navigate({
+            to: "/databases/mongo/$namespace/$name",
+            params: { namespace: ns, name: a.metadata.name ?? "" },
+          });
+        } else {
+          // Postgres -> the CloudNativePG cluster detail (cluster <app>-db).
           navigate({
             to: "/databases/$namespace/$name",
-            params: {
-              namespace: a.metadata.namespace ?? "default",
-              name: `${a.metadata.name}-db`,
-            },
+            params: { namespace: ns, name: `${a.metadata.name}-db` },
           });
         }
       }}
     />
+      <NewDatabaseDialog
+        open={newOpen}
+        onOpenChange={setNewOpen}
+        namespaces={namespaces}
+        defaultNamespace={scoped || "default"}
+        listPath={openinfraPaths.applications(scoped)}
+      />
+    </>
   );
 }

--- a/ui/src/features/databases/mongo-detail-page.tsx
+++ b/ui/src/features/databases/mongo-detail-page.tsx
@@ -3,6 +3,7 @@ import { useParams } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { Database, Eye, EyeOff } from "lucide-react";
 import { DetailShell } from "@/components/common/detail-shell";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DetailRow } from "@/components/common/detail-row";
@@ -10,10 +11,10 @@ import { CopyButton } from "@/components/common/copy-button";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
 import { LoadingState, ErrorState } from "@/components/common/states";
+import { claimHealth } from "@/lib/resource-health";
 import { k8sGet } from "@/lib/api";
-import { cnpgPaths } from "@/lib/k8s-paths";
-import { type StatusTone } from "@/lib/format";
-import type { CnpgCluster, K8sObject } from "@/types/k8s";
+import { openinfraPaths } from "@/lib/k8s-paths";
+import type { Application, K8sObject } from "@/types/k8s";
 
 function decode(v?: string): string {
   if (!v) return "";
@@ -24,57 +25,52 @@ function decode(v?: string): string {
   }
 }
 
-function dbTone(phase?: string): StatusTone {
-  if (!phase) return "muted";
-  const p = phase.toLowerCase();
-  if (p.includes("healthy")) return "success";
-  if (p.includes("fail") || p.includes("unhealth") || p.includes("error"))
-    return "destructive";
-  return "warning";
-}
-
-export function DatabaseDetailPage() {
+/**
+ * Detail view for a mongo (FerretDB) database. Unlike postgres there's no CNPG
+ * Cluster CR; the database is the FerretDB + DocumentDB-Postgres stack a mongo
+ * Application provisions, so we key off the owning Application and its
+ * connection secret (<app>-mongo-app). Route name param = the Application name.
+ */
+export function MongoDetailPage() {
   const { namespace, name } = useParams({ strict: false }) as {
     namespace: string;
     name: string;
   };
   const [showUri, setShowUri] = useState(false);
 
-  const { data: db, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ["database", namespace, name],
-    queryFn: () => k8sGet<CnpgCluster>(cnpgPaths.cluster(namespace, name)),
+  const { data: app, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["mongo-app", namespace, name],
+    queryFn: () => k8sGet<Application>(openinfraPaths.application(namespace, name)),
   });
   const { data: secret } = useQuery({
-    queryKey: ["database-secret", namespace, name],
+    queryKey: ["mongo-secret", namespace, name],
     queryFn: () =>
-      k8sGet<K8sObject & { data?: Record<string, string> }>(
-        `/api/v1/namespaces/${namespace}/secrets/${name}-app`,
+      k8sGet<K8sObject<unknown, unknown> & { data?: Record<string, string> }>(
+        `/api/v1/namespaces/${namespace}/secrets/${name}-mongo-app`,
       ),
     retry: false,
   });
 
   if (isLoading) return <LoadingState label="Loading database…" />;
-  if (isError || !db) return <ErrorState error={error} onRetry={refetch} />;
+  if (isError || !app) return <ErrorState error={error} onRetry={refetch} />;
 
-  const d = secret?.data ?? {};
-  const uri = decode(d["uri"]);
-  const phase = db.status?.phase;
-  const ready = db.status?.readyInstances ?? 0;
-  const total = db.spec?.instances ?? db.status?.instances ?? 1;
+  const db = app.spec?.database;
+  const uri = decode(secret?.data?.["MONGODB_URI"]);
+  const health = claimHealth(app);
+  const ha = Boolean(db?.highAvailability);
 
   return (
     <DetailShell
       backTo="/databases"
       backLabel="Databases"
       icon={<Database className="size-5" />}
-      title={name}
-      subtitle={`Managed PostgreSQL · ${namespace}`}
-      status={phase ? { label: phase, tone: dbTone(phase) } : null}
+      title={db?.name ?? name}
+      subtitle={`MongoDB (FerretDB) · ${namespace}`}
+      status={health}
     >
       <Tabs defaultValue="overview">
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
-          <TabsTrigger value="connectivity">Connectivity</TabsTrigger>
           <TabsTrigger value="monitoring">Monitoring</TabsTrigger>
           <TabsTrigger value="yaml">YAML</TabsTrigger>
         </TabsList>
@@ -82,38 +78,28 @@ export function DatabaseDetailPage() {
         <TabsContent value="overview" className="pt-4">
           <Card>
             <CardContent className="divide-y divide-border p-0">
-              <DetailRow label="Status">{phase ?? "—"}</DetailRow>
-              <DetailRow label="Instances">
-                {ready}/{total} ready
+              <DetailRow label="Engine">
+                <Badge variant="secondary">MongoDB (FerretDB)</Badge>
               </DetailRow>
-              <DetailRow label="Storage">
-                {db.spec?.storage?.size ?? "—"} (
-                {db.spec?.storage?.storageClass ?? "default"})
+              <DetailRow label="Database">{db?.name ?? "—"}</DetailRow>
+              <DetailRow label="Namespace">{namespace}</DetailRow>
+              <DetailRow label="Application">{name}</DetailRow>
+              <DetailRow label="High availability">
+                {ha
+                  ? "On · 2 FerretDB replicas (proxy tier)"
+                  : "Off (single replica)"}
               </DetailRow>
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        <TabsContent value="connectivity" className="pt-4">
-          <Card>
-            <CardContent className="divide-y divide-border p-0">
-              <DetailRow label="Host">
-                {decode(d["host"]) || `${name}-rw.${namespace}.svc`}
-              </DetailRow>
-              <DetailRow label="Port">{decode(d["port"]) || "5432"}</DetailRow>
-              <DetailRow label="Database">{decode(d["dbname"]) || "—"}</DetailRow>
-              <DetailRow label="User">{decode(d["user"]) || "—"}</DetailRow>
-              <DetailRow label="Connection URI">
+              <DetailRow label="Connection (MONGODB_URI)">
                 <span className="flex items-center gap-1">
-                  <code className="max-w-[26rem] truncate text-xs">
-                    {uri ? (showUri ? uri : "postgresql://•••") : "—"}
+                  <code className="text-xs">
+                    {uri ? (showUri ? uri : "•".repeat(16)) : "—"}
                   </code>
                   {uri ? (
                     <>
                       <button
-                        onClick={() => setShowUri((v) => !v)}
+                        onClick={() => setShowUri((s) => !s)}
                         className="text-muted-foreground hover:text-foreground"
-                        aria-label={showUri ? "Hide" : "Show"}
+                        aria-label={showUri ? "Hide URI" : "Show URI"}
                       >
                         {showUri ? (
                           <EyeOff className="size-4" />
@@ -126,19 +112,26 @@ export function DatabaseDetailPage() {
                   ) : null}
                 </span>
               </DetailRow>
+              <DetailRow label="Apps consume it via">
+                <code className="text-xs">MONGODB_URI</code> (any MongoDB driver)
+              </DetailRow>
             </CardContent>
           </Card>
         </TabsContent>
 
         <TabsContent value="monitoring" className="pt-4">
+          {/* Scoped to this database's FerretDB + DocumentDB-Postgres pods. */}
           <GrafanaEmbed
             uid="openinfra-app-overview"
-            vars={{ "var-namespace": namespace, "var-pod": `${name}-.*` }}
+            vars={{
+              "var-namespace": namespace,
+              "var-pod": `${name}-(mongo|docdb)-.*`,
+            }}
           />
         </TabsContent>
 
         <TabsContent value="yaml" className="pt-4">
-          <YamlViewer value={db} />
+          <YamlViewer value={app} />
         </TabsContent>
       </Tabs>
     </DetailShell>

--- a/ui/src/features/databases/new-database-dialog.tsx
+++ b/ui/src/features/databases/new-database-dialog.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Database, Rocket } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/common/states";
+import { ApiError, k8sCreate } from "@/lib/api";
+import { openinfraPaths } from "@/lib/k8s-paths";
+import { watchQueryKey } from "@/hooks/use-k8s-watch";
+import {
+  OPENINFRA_GROUP,
+  OPENINFRA_VERSION,
+  type K8sObject,
+} from "@/types/k8s";
+
+const RFC1123 = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+/**
+ * Hand-roll a database without writing an Application YAML: pick a name, engine
+ * (postgres / mongo) and HA. Creates a *data-only* Application (no image), which
+ * the platform compiles into just the database.
+ */
+export function NewDatabaseDialog({
+  open,
+  onOpenChange,
+  namespaces,
+  defaultNamespace,
+  listPath,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  namespaces: string[];
+  defaultNamespace?: string;
+  listPath: string;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [namespace, setNamespace] = useState(defaultNamespace ?? "default");
+  const [engine, setEngine] = useState("postgres");
+  const [ha, setHa] = useState(false);
+  const [touched, setTouched] = useState(false);
+
+  function reset() {
+    setName("");
+    setEngine("postgres");
+    setHa(false);
+    setTouched(false);
+    createMutation.reset();
+  }
+
+  const createMutation = useMutation({
+    mutationFn: (manifest: K8sObject) =>
+      k8sCreate<K8sObject>(openinfraPaths.applications(namespace), manifest),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: watchQueryKey(listPath) });
+      reset();
+      onOpenChange(false);
+    },
+  });
+
+  const nameError =
+    touched && !RFC1123.test(name)
+      ? "Lowercase letters, numbers and hyphens; must start/end alphanumeric."
+      : null;
+
+  const submit = () => {
+    if (!RFC1123.test(name)) {
+      setTouched(true);
+      return;
+    }
+    createMutation.mutate({
+      apiVersion: `${OPENINFRA_GROUP}/${OPENINFRA_VERSION}`,
+      kind: "Application",
+      metadata: { name, namespace },
+      // Data-only Application: just a database, no workload.
+      spec: { database: { engine, name, highAvailability: ha } },
+    } as K8sObject);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (createMutation.isPending) return;
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Database className="size-5 text-primary" />
+            New Database
+          </DialogTitle>
+          <DialogDescription>
+            Provisions a managed database directly — no Application YAML needed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="db-name">Name</Label>
+            <Input
+              id="db-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={() => setTouched(true)}
+              placeholder="my-db"
+              autoFocus
+            />
+            {nameError ? (
+              <p className="text-xs text-destructive">{nameError}</p>
+            ) : null}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="db-ns">Namespace</Label>
+            <Select value={namespace} onValueChange={setNamespace}>
+              <SelectTrigger id="db-ns">
+                <SelectValue placeholder="Namespace" />
+              </SelectTrigger>
+              <SelectContent>
+                {(namespaces.length ? namespaces : [namespace]).map((ns) => (
+                  <SelectItem key={ns} value={ns}>
+                    {ns}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="db-engine">Engine</Label>
+            <Select value={engine} onValueChange={setEngine}>
+              <SelectTrigger id="db-engine">
+                <SelectValue placeholder="Engine" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="postgres">PostgreSQL (relational)</SelectItem>
+                <SelectItem value="mongo">MongoDB / FerretDB (document)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label>High availability</Label>
+            <label className="flex h-9 items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={ha}
+                onChange={(e) => setHa(e.target.checked)}
+                className="size-4 accent-primary"
+              />
+              <span className="text-muted-foreground">
+                {engine === "mongo"
+                  ? "2 FerretDB replicas (proxy tier)"
+                  : "Primary + standby, auto-failover"}
+              </span>
+            </label>
+          </div>
+        </div>
+
+        {createMutation.error ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            {createMutation.error instanceof ApiError
+              ? createMutation.error.message
+              : "Failed to create the database."}
+          </div>
+        ) : null}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={createMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={createMutation.isPending || !RFC1123.test(name)}
+          >
+            {createMutation.isPending ? (
+              <Spinner className="text-current" />
+            ) : (
+              <Rocket className="size-4" />
+            )}
+            Create Database
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/features/functions/function-detail-page.tsx
+++ b/ui/src/features/functions/function-detail-page.tsx
@@ -269,7 +269,7 @@ export function FunctionDetailPage() {
         <TabsContent value="monitoring" className="pt-4">
           <GrafanaEmbed
             uid="openinfra-app-overview"
-            vars={{ "var-namespace": namespace }}
+            vars={{ "var-namespace": namespace, "var-pod": `${name}-.*` }}
           />
         </TabsContent>
 

--- a/ui/src/features/models/model-detail-page.tsx
+++ b/ui/src/features/models/model-detail-page.tsx
@@ -280,8 +280,21 @@ export function ModelDetailPage() {
           </Card>
         </TabsContent>
 
-        <TabsContent value="monitoring" className="pt-4">
-          <GrafanaEmbed uid="openinfra-gpu-overview" />
+        <TabsContent value="monitoring" className="space-y-4 pt-4">
+          {/* Resource-scoped: this model's own pods (CPU / memory / logs). */}
+          <div>
+            <p className="pb-2 text-sm font-medium">This model</p>
+            <GrafanaEmbed
+              uid="openinfra-app-overview"
+              vars={{ "var-namespace": namespace, "var-pod": `${name}-.*` }}
+              height={460}
+            />
+          </div>
+          {/* GPU metrics are per-device (cluster-wide) — shown for context. */}
+          <div>
+            <p className="pb-2 text-sm font-medium">GPU devices (cluster)</p>
+            <GrafanaEmbed uid="openinfra-gpu-overview" height={460} />
+          </div>
         </TabsContent>
 
         <TabsContent value="yaml" className="pt-4">

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -14,6 +14,7 @@ import { ModelsPage } from "@/features/models/models-page";
 import { ModelDetailPage } from "@/features/models/model-detail-page";
 import { DatabasesPage } from "@/features/databases/databases-page";
 import { DatabaseDetailPage } from "@/features/databases/database-detail-page";
+import { MongoDetailPage } from "@/features/databases/mongo-detail-page";
 import { QueueDetailPage } from "@/features/queues/queue-detail-page";
 import { BucketsPage } from "@/features/buckets/buckets-page";
 import { BucketDetailPage } from "@/features/buckets/bucket-detail-page";
@@ -77,6 +78,12 @@ const databaseDetailRoute = createRoute({
   component: DatabaseDetailPage,
 });
 
+const mongoDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/databases/mongo/$namespace/$name",
+  component: MongoDetailPage,
+});
+
 const bucketsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/buckets",
@@ -134,6 +141,7 @@ const routeTree = rootRoute.addChildren([
   modelDetailRoute,
   databasesRoute,
   databaseDetailRoute,
+  mongoDetailRoute,
   bucketsRoute,
   bucketDetailRoute,
   queuesRoute,


### PR DESCRIPTION
Closes #34, #33, #31 — three related console/DB polish items.

## #34 — Grafana panels scoped to the resource
Panels were filtered by **namespace only**, so a Function/Database/Model detail showed *everything* in the namespace (and in the demo, many resources share one namespace).
- The `app-overview` dashboard gains a **`pod` regex** template variable; all three panels filter `pod=~"$pod"`.
- Function, Database, and Model detail pages pass `var-pod=<name>-.*` → each panel shows **only that resource's pods**.
- The **Model** also gets a resource-scoped app panel (its own CPU/mem/logs) above the per-device GPU view (GPU metrics are device-level, labeled "cluster").

## #33 — FerretDB/mongo detail page
Mongo databases had no clickable detail like postgres. New **MongoDetailPage** keyed off the owning Application + its `<app>-mongo-app` secret: engine, database name, HA, **connection URI** (reveal/copy), scoped monitoring, YAML. Databases rows route **postgres → CNPG detail**, **mongo → FerretDB detail**.

## #31 — hand-roll a database from the console
Creating a DB required a full Application YAML. Now an Application can be **data-only**:
- `image`/`port` are **optional** in the XRD; the workload (Deployment/Service/Ingress/HPA) renders **only when an image is set** — verified by offline render (db-only → just the DB + namespace guardrails, no workload).
- A focused **New Database** dialog (name / namespace / engine / HA) creates a data-only Application.

## Testing
- Composition rendered offline (Sprig) across app+postgres / app+mongo / **db-only-postgres** / **db-only-mongo** — all valid; db-only correctly omits the workload.
- `kubectl apply --dry-run=server` validates the dashboard, XRD, and composition.
- `tsc` + `npm run build` (node:22) green.

Note: the dashboard ConfigMap + composition sync via Argo on merge; the console UI needs the image rebuild + rollout.

Closes #34
Closes #33
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)