### PR TITLE
feat(console): OIRN resource identifiers + Danger Zone delete sections

### DIFF
--- a/cli/open-infra
+++ b/cli/open-infra
@@ -3,6 +3,7 @@
 #   open-infra init [app|model|function]  scaffold an infra.yaml (Application / Model / Function)
 #   open-infra deploy   validate infra.yaml, render the CR, commit to GitOps
 #   open-infra status   show your apps, models, and their health
+#   open-infra oirn     print the resource name (OIRN) of every resource
 #   open-infra logs     tail logs for an app
 set -euo pipefail
 
@@ -10,7 +11,17 @@ KUBECTL="${KUBECTL:-kubectl}"
 command -v "$KUBECTL" >/dev/null 2>&1 || KUBECTL="k3s kubectl"
 SELF="open-infra"
 
-usage() { sed -n '2,6p' "$0" | sed 's/^# \{0,1\}//'; }
+usage() { sed -n '2,7p' "$0" | sed 's/^# \{0,1\}//'; }
+
+# Cluster name for OIRNs — matches the console (its CLUSTER_NAME env), falling
+# back to $CLUSTER_NAME then "local" so identifiers line up across CLI + UI.
+cluster_name() {
+  local c="${CLUSTER_NAME:-}"
+  [ -n "$c" ] && { printf '%s' "$c"; return; }
+  c="$($KUBECTL -n open-infra-console get deploy console \
+        -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CLUSTER_NAME")].value}' 2>/dev/null)" || true
+  printf '%s' "${c:-local}"
+}
 
 cmd_init() {
   [ -f infra.yaml ] && { echo "infra.yaml already exists"; exit 0; }
@@ -98,6 +109,26 @@ cmd_status() {
   $KUBECTL get functions.openinfra.dev -A 2>/dev/null || echo "(none yet)"
   echo; echo "== Argo CD =="
   $KUBECTL -n argocd get applications 2>/dev/null || echo "(Argo not installed)"
+  echo; echo "(resource names: $SELF oirn)"
+}
+
+# Print an OIRN (oirn:openinfra:<cluster>:<namespace>:<kind>/<name>) for every
+# resource — the AWS-ARN analog, derived from each object's identity.
+cmd_oirn() {
+  local cluster; cluster="$(cluster_name)"
+  printf '%-11s %s\n' "KIND" "OIRN"
+  local entry kind crd ns nm
+  for entry in application:applications.openinfra.dev \
+               model:models.openinfra.dev \
+               function:functions.openinfra.dev; do
+    kind="${entry%%:*}"; crd="${entry#*:}"
+    $KUBECTL get "$crd" -A \
+      -o jsonpath="{range .items[*]}{.metadata.namespace} {.metadata.name}{'\n'}{end}" 2>/dev/null \
+      | while read -r ns nm; do
+          [ -n "${nm:-}" ] && printf '%-11s oirn:openinfra:%s:%s:%s/%s\n' \
+            "$kind" "$cluster" "$ns" "$kind" "$nm"
+        done
+  done
 }
 
 cmd_logs() {
@@ -109,6 +140,7 @@ case "${1:-}" in
   init)   shift; cmd_init "$@" ;;
   deploy) cmd_deploy ;;
   status) cmd_status ;;
+  oirn)   cmd_oirn ;;
   logs)   shift; cmd_logs "$@" ;;
   ""|-h|--help) usage ;;
   *) echo "unknown command: $1" >&2; usage; exit 1 ;;

--- a/ui/src/components/common/danger-zone.tsx
+++ b/ui/src/components/common/danger-zone.tsx
@@ -1,0 +1,66 @@
+import { type ReactNode, useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/common/confirm-dialog";
+
+/**
+ * A consistent "Danger Zone" block for resource detail pages: a destructive
+ * card with a delete action gated behind a confirm dialog. Drop it at the
+ * bottom of a detail page; pass the delete mutation via onConfirm.
+ */
+export function DangerZone({
+  resourceLabel,
+  resourceName,
+  onConfirm,
+  deleting,
+  description,
+  confirmDescription,
+}: {
+  /** Human label, e.g. "Model", "Database". */
+  resourceLabel: string;
+  /** The resource's name, shown in the confirm dialog. */
+  resourceName: string;
+  onConfirm: () => void;
+  deleting?: boolean;
+  /** Optional override for the card's explanatory text. */
+  description?: ReactNode;
+  /** Optional override for the confirm dialog body. */
+  confirmDescription?: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Card className="border-destructive/40">
+      <CardContent className="flex flex-wrap items-center justify-between gap-4 p-5">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-destructive">Danger Zone</h3>
+          <p className="text-sm text-muted-foreground">
+            {description ??
+              `Permanently delete this ${resourceLabel.toLowerCase()}. This cannot be undone.`}
+          </p>
+        </div>
+        <Button variant="destructive" onClick={() => setOpen(true)}>
+          <Trash2 className="size-4" />
+          Delete {resourceLabel}
+        </Button>
+      </CardContent>
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={`Delete ${resourceLabel}?`}
+        description={
+          confirmDescription ?? (
+            <>
+              Permanently delete{" "}
+              <span className="font-medium text-foreground">{resourceName}</span>.
+              This cannot be undone.
+            </>
+          )
+        }
+        confirmLabel="Delete"
+        loading={deleting}
+        onConfirm={onConfirm}
+      />
+    </Card>
+  );
+}

--- a/ui/src/components/common/resource-name-row.tsx
+++ b/ui/src/components/common/resource-name-row.tsx
@@ -1,0 +1,30 @@
+import { DetailRow } from "@/components/common/detail-row";
+import { CopyButton } from "@/components/common/copy-button";
+import { useConfig } from "@/lib/config-context";
+import { oirn } from "@/lib/oirn";
+
+/**
+ * A copyable "Resource name" (OIRN) row for detail pages — the AWS-ARN analog.
+ * Computes the OIRN from the cluster (runtime config) + the resource identity.
+ * Drop it inside a Card's divided CardContent alongside other DetailRows.
+ */
+export function ResourceNameRow({
+  kind,
+  name,
+  namespace,
+}: {
+  kind: string;
+  name: string;
+  namespace?: string;
+}) {
+  const { clusterName } = useConfig();
+  const id = oirn({ kind, name, cluster: clusterName, namespace });
+  return (
+    <DetailRow label="Resource name">
+      <span className="flex items-center gap-1">
+        <code className="text-xs">{id}</code>
+        <CopyButton value={id} />
+      </span>
+    </DetailRow>
+  );
+}

--- a/ui/src/features/applications/application-detail.tsx
+++ b/ui/src/features/applications/application-detail.tsx
@@ -12,6 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { StatusBadge } from "@/components/common/status-badge";
 import { DetailRow, KeyValueList } from "@/components/common/detail-row";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
 import { CopyButton } from "@/components/common/copy-button";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { age, formatTimestamp } from "@/lib/format";
@@ -76,6 +77,11 @@ export function ApplicationDetail({
                   ) : null}
 
                   <dl className="divide-y divide-border">
+                    <ResourceNameRow
+                      kind="application"
+                      name={app.metadata.name}
+                      namespace={app.metadata.namespace}
+                    />
                     <DetailRow label="Image">
                       <span className="flex items-center gap-1.5">
                         <code className="break-all text-xs">
@@ -234,7 +240,10 @@ export function ApplicationDetail({
             </div>
 
             <Separator />
-            <div className="flex items-center justify-end gap-2 p-4">
+            <div className="flex items-center justify-between gap-2 p-4">
+              <span className="text-sm font-semibold text-destructive">
+                Danger Zone
+              </span>
               <Button variant="destructive" onClick={() => onDelete(app)}>
                 <Trash2 className="size-4" />
                 Delete

--- a/ui/src/features/buckets/bucket-detail-page.tsx
+++ b/ui/src/features/buckets/bucket-detail-page.tsx
@@ -16,6 +16,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DetailRow } from "@/components/common/detail-row";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DangerZone } from "@/components/common/danger-zone";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import {
   EmptyState,
@@ -197,7 +199,6 @@ function ObjectsTab({ bucket }: { bucket: string }) {
 export function BucketDetailPage() {
   const { bucket } = useParams({ strict: false }) as { bucket: string };
   const navigate = useNavigate();
-  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const { data: buckets } = useQuery({ queryKey: ["buckets"], queryFn: listBuckets });
   const meta = buckets?.find((b) => b.name === bucket);
@@ -214,12 +215,6 @@ export function BucketDetailPage() {
       icon={<HardDrive className="size-5" />}
       title={bucket}
       subtitle="Object storage bucket (MinIO / S3)"
-      actions={
-        <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-          <Trash2 className="size-4" />
-          Delete bucket
-        </Button>
-      }
     >
       <Tabs defaultValue="objects">
         <TabsList>
@@ -232,6 +227,7 @@ export function BucketDetailPage() {
         <TabsContent value="properties" className="pt-4">
           <Card>
             <CardContent className="divide-y divide-border p-0">
+              <ResourceNameRow kind="bucket" name={bucket} />
               <DetailRow label="Name">{bucket}</DetailRow>
               <DetailRow label="Created">
                 {meta ? age(meta.createdAt) + " ago" : "—"}
@@ -244,20 +240,18 @@ export function BucketDetailPage() {
         </TabsContent>
       </Tabs>
 
-      <ConfirmDialog
-        open={confirmDelete}
-        onOpenChange={setConfirmDelete}
-        title="Delete bucket?"
-        description={
+      <DangerZone
+        resourceLabel="Bucket"
+        resourceName={bucket}
+        deleting={deleteMutation.isPending}
+        onConfirm={() => deleteMutation.mutate()}
+        confirmDescription={
           <>
             Permanently delete bucket{" "}
             <span className="font-medium text-foreground">{bucket}</span> and all
             its objects. This cannot be undone.
           </>
         }
-        confirmLabel="Delete bucket"
-        loading={deleteMutation.isPending}
-        onConfirm={() => deleteMutation.mutate()}
       />
     </DetailShell>
   );

--- a/ui/src/features/databases/database-detail-page.tsx
+++ b/ui/src/features/databases/database-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useParams } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useParams, useNavigate } from "@tanstack/react-router";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Database, Eye, EyeOff } from "lucide-react";
 import { DetailShell } from "@/components/common/detail-shell";
 import { Card, CardContent } from "@/components/ui/card";
@@ -9,9 +9,11 @@ import { DetailRow } from "@/components/common/detail-row";
 import { CopyButton } from "@/components/common/copy-button";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DangerZone } from "@/components/common/danger-zone";
 import { LoadingState, ErrorState } from "@/components/common/states";
-import { k8sGet } from "@/lib/api";
-import { cnpgPaths } from "@/lib/k8s-paths";
+import { k8sDelete, k8sGet } from "@/lib/api";
+import { cnpgPaths, openinfraPaths } from "@/lib/k8s-paths";
 import { type StatusTone } from "@/lib/format";
 import type { CnpgCluster, K8sObject } from "@/types/k8s";
 
@@ -39,6 +41,15 @@ export function DatabaseDetailPage() {
     name: string;
   };
   const [showUri, setShowUri] = useState(false);
+  const navigate = useNavigate();
+  // The CNPG cluster is named "<app>-db" and owned by its Application; deleting
+  // the database means deleting that Application (Crossplane would otherwise
+  // recreate the cluster). Strip the "-db" suffix to get the app name.
+  const appName = name.replace(/-db$/, "");
+  const deleteMutation = useMutation({
+    mutationFn: () => k8sDelete(openinfraPaths.application(namespace, appName)),
+    onSuccess: () => navigate({ to: "/databases" }),
+  });
 
   const { data: db, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["database", namespace, name],
@@ -82,6 +93,7 @@ export function DatabaseDetailPage() {
         <TabsContent value="overview" className="pt-4">
           <Card>
             <CardContent className="divide-y divide-border p-0">
+              <ResourceNameRow kind="database" name={name} namespace={namespace} />
               <DetailRow label="Status">{phase ?? "—"}</DetailRow>
               <DetailRow label="Instances">
                 {ready}/{total} ready
@@ -141,6 +153,20 @@ export function DatabaseDetailPage() {
           <YamlViewer value={db} />
         </TabsContent>
       </Tabs>
+
+      <DangerZone
+        resourceLabel="Database"
+        resourceName={name}
+        deleting={deleteMutation.isPending}
+        onConfirm={() => deleteMutation.mutate()}
+        confirmDescription={
+          <>
+            Permanently delete the application{" "}
+            <span className="font-medium text-foreground">{appName}</span> and its
+            PostgreSQL database. This cannot be undone.
+          </>
+        }
+      />
     </DetailShell>
   );
 }

--- a/ui/src/features/databases/mongo-detail-page.tsx
+++ b/ui/src/features/databases/mongo-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useParams } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useParams, useNavigate } from "@tanstack/react-router";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Database, Eye, EyeOff } from "lucide-react";
 import { DetailShell } from "@/components/common/detail-shell";
 import { Badge } from "@/components/ui/badge";
@@ -10,9 +10,11 @@ import { DetailRow } from "@/components/common/detail-row";
 import { CopyButton } from "@/components/common/copy-button";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DangerZone } from "@/components/common/danger-zone";
 import { LoadingState, ErrorState } from "@/components/common/states";
 import { claimHealth } from "@/lib/resource-health";
-import { k8sGet } from "@/lib/api";
+import { k8sDelete, k8sGet } from "@/lib/api";
 import { openinfraPaths } from "@/lib/k8s-paths";
 import type { Application, K8sObject } from "@/types/k8s";
 
@@ -37,6 +39,11 @@ export function MongoDetailPage() {
     name: string;
   };
   const [showUri, setShowUri] = useState(false);
+  const navigate = useNavigate();
+  const deleteMutation = useMutation({
+    mutationFn: () => k8sDelete(openinfraPaths.application(namespace, name)),
+    onSuccess: () => navigate({ to: "/databases" }),
+  });
 
   const { data: app, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["mongo-app", namespace, name],
@@ -78,6 +85,7 @@ export function MongoDetailPage() {
         <TabsContent value="overview" className="pt-4">
           <Card>
             <CardContent className="divide-y divide-border p-0">
+              <ResourceNameRow kind="database" name={name} namespace={namespace} />
               <DetailRow label="Engine">
                 <Badge variant="secondary">MongoDB (FerretDB)</Badge>
               </DetailRow>
@@ -134,6 +142,20 @@ export function MongoDetailPage() {
           <YamlViewer value={app} />
         </TabsContent>
       </Tabs>
+
+      <DangerZone
+        resourceLabel="Database"
+        resourceName={db?.name ?? name}
+        deleting={deleteMutation.isPending}
+        onConfirm={() => deleteMutation.mutate()}
+        confirmDescription={
+          <>
+            Permanently delete the application{" "}
+            <span className="font-medium text-foreground">{name}</span> and its
+            FerretDB database. This cannot be undone.
+          </>
+        }
+      />
     </DetailShell>
   );
 }

--- a/ui/src/features/functions/function-detail-page.tsx
+++ b/ui/src/features/functions/function-detail-page.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ExternalLink, Send, Trash2, Zap } from "lucide-react";
+import { ExternalLink, Send, Zap } from "lucide-react";
 import { DetailShell } from "@/components/common/detail-shell";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -11,7 +11,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DetailRow } from "@/components/common/detail-row";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
-import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DangerZone } from "@/components/common/danger-zone";
 import { LoadingState, ErrorState } from "@/components/common/states";
 import { claimHealth } from "@/lib/resource-health";
 import {
@@ -169,7 +170,6 @@ export function FunctionDetailPage() {
     name: string;
   };
   const navigate = useNavigate();
-  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const { data: fn, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["function", namespace, name],
@@ -196,12 +196,6 @@ export function FunctionDetailPage() {
       title={name}
       subtitle={`Serverless function · ${namespace}`}
       status={claimHealth(fn)}
-      actions={
-        <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-          <Trash2 className="size-4" />
-          Delete
-        </Button>
-      }
     >
       <Tabs defaultValue="test">
         <TabsList>
@@ -218,6 +212,7 @@ export function FunctionDetailPage() {
         <TabsContent value="overview" className="pt-4">
           <Card>
             <CardContent className="divide-y divide-border p-0">
+              <ResourceNameRow kind="function" name={name} namespace={namespace} />
               <DetailRow label="Image">
                 <code className="text-xs">{s?.image ?? "—"}</code>
               </DetailRow>
@@ -278,18 +273,10 @@ export function FunctionDetailPage() {
         </TabsContent>
       </Tabs>
 
-      <ConfirmDialog
-        open={confirmDelete}
-        onOpenChange={setConfirmDelete}
-        title="Delete Function?"
-        description={
-          <>
-            Permanently delete{" "}
-            <span className="font-medium text-foreground">{name}</span>.
-          </>
-        }
-        confirmLabel="Delete"
-        loading={deleteMutation.isPending}
+      <DangerZone
+        resourceLabel="Function"
+        resourceName={name}
+        deleting={deleteMutation.isPending}
         onConfirm={() => deleteMutation.mutate()}
       />
     </DetailShell>

--- a/ui/src/features/models/model-detail-page.tsx
+++ b/ui/src/features/models/model-detail-page.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Bot, BrainCircuit, Eye, EyeOff, Send, Trash2 } from "lucide-react";
+import { Bot, BrainCircuit, Eye, EyeOff, Send } from "lucide-react";
 import { DetailShell } from "@/components/common/detail-shell";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -11,7 +11,8 @@ import { DetailRow } from "@/components/common/detail-row";
 import { CopyButton } from "@/components/common/copy-button";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
-import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DangerZone } from "@/components/common/danger-zone";
 import { LoadingState, ErrorState } from "@/components/common/states";
 import { modelHealth, modelDesiredReplicas } from "@/lib/resource-health";
 import { ApiError, k8sDelete, k8sGet, modelChat, type ChatMessage } from "@/lib/api";
@@ -129,7 +130,6 @@ export function ModelDetailPage() {
     name: string;
   };
   const [showKey, setShowKey] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
   const navigate = useNavigate();
   const { offlineNodes } = useNodeHealth();
   const podIndex = usePodNodeIndex(namespace);
@@ -175,12 +175,6 @@ export function ModelDetailPage() {
       title={name}
       subtitle={`Managed inference · ${model.spec?.model ?? ""}`}
       status={health}
-      actions={
-        <Button variant="destructive" onClick={() => setConfirmDelete(true)}>
-          <Trash2 className="size-4" />
-          Delete
-        </Button>
-      }
     >
       <Tabs defaultValue="playground">
         <TabsList>
@@ -197,6 +191,7 @@ export function ModelDetailPage() {
         <TabsContent value="overview" className="pt-4">
           <Card>
             <CardContent className="divide-y divide-border p-0">
+              <ResourceNameRow kind="model" name={name} namespace={namespace} />
               <DetailRow label="Model">{model.spec?.model ?? "—"}</DetailRow>
               <DetailRow label="High availability">
                 {model.spec?.highAvailability ? (
@@ -302,20 +297,18 @@ export function ModelDetailPage() {
         </TabsContent>
       </Tabs>
 
-      <ConfirmDialog
-        open={confirmDelete}
-        onOpenChange={setConfirmDelete}
-        title="Delete Model?"
-        description={
+      <DangerZone
+        resourceLabel="Model"
+        resourceName={name}
+        deleting={deleteMutation.isPending}
+        onConfirm={() => deleteMutation.mutate()}
+        confirmDescription={
           <>
             Permanently delete{" "}
             <span className="font-medium text-foreground">{name}</span> and its
-            GPU-backed endpoint.
+            GPU-backed endpoint. This cannot be undone.
           </>
         }
-        confirmLabel="Delete"
-        loading={deleteMutation.isPending}
-        onConfirm={() => deleteMutation.mutate()}
       />
     </DetailShell>
   );

--- a/ui/src/features/queues/queue-detail-page.tsx
+++ b/ui/src/features/queues/queue-detail-page.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DetailRow } from "@/components/common/detail-row";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
 import { ConfirmDialog } from "@/components/common/confirm-dialog";
 import { LoadingState, ErrorState, EmptyState } from "@/components/common/states";
 import { listQueues, publishToQueue, purgeQueue } from "@/lib/api";
@@ -86,6 +87,7 @@ export function QueueDetailPage() {
         <TabsContent value="overview" className="pt-4">
           <Card>
             <CardContent className="divide-y divide-border p-0">
+              <ResourceNameRow kind="queue" name={stream} />
               <DetailRow label="Messages">
                 {s.messages.toLocaleString()}
               </DetailRow>

--- a/ui/src/lib/oirn.ts
+++ b/ui/src/lib/oirn.ts
@@ -1,0 +1,20 @@
+/**
+ * OIRN — open-infra Resource Name. A stable, AWS-ARN-style handle for any
+ * resource, DERIVED from its Kubernetes identity (cluster + namespace + kind +
+ * name) rather than stored, so it never drifts.
+ *
+ *   oirn:openinfra:<cluster>:<namespace>:<kind>/<name>
+ *
+ * Cluster-scoped resources (bucket, queue, node) leave the namespace segment
+ * empty: oirn:openinfra:<cluster>::bucket/<name>
+ */
+export function oirn(opts: {
+  kind: string;
+  name: string;
+  cluster?: string;
+  namespace?: string;
+}): string {
+  const cluster = opts.cluster?.trim() || "local";
+  const ns = opts.namespace ?? "";
+  return `oirn:openinfra:${cluster}:${ns}:${opts.kind}/${opts.name}`;
+}


### PR DESCRIPTION
Two resource-UX additions requested in conversation.

## OIRN — an ARN-style resource identifier
AWS gives every resource an ARN; Kubernetes already has canonical identity (GVK + namespace + name + uid) but no friendly handle. This adds **OIRN** (open-infra Resource Name), **derived** from identity (never stored, so no drift):

```
oirn:openinfra:<cluster>:<namespace>:<kind>/<name>
e.g. oirn:openinfra:homelab:demo:model/demo-chat
```
- `lib/oirn.ts` + a copyable **Resource name** row on every detail page (application / model / function / database / mongo / bucket / queue). Cluster-scoped kinds (bucket/queue) leave the namespace segment empty.
- **CLI**: `open-infra oirn` prints the OIRN of every resource, reading the **same cluster name as the console** (its `CLUSTER_NAME`) so CLI + UI identifiers match.

## Danger Zone — consistent delete on every detail page
A reusable `DangerZone` (destructive card + confirm dialog) so anything spawned from the web can be removed in one consistent place:
- **model / function / bucket** — moved their existing delete into the Danger Zone.
- **database (postgres) + mongo** — **new** delete: removes the owning Application (postgres derives the app by stripping the `-db` suffix; Crossplane would otherwise recreate the cluster).
- **application** — existing delete footer relabeled "Danger Zone".

## Testing
- `tsc -b` + `npm run build` (node:22) green.
- `open-infra oirn` run live — emits correct OIRNs for every Application/Model/Function.
- `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)