### PR TITLE
feat(db): opt-in LAN access for databases (expose -> MetalLB LoadBalancer)

### DIFF
--- a/cli/open-infra
+++ b/cli/open-infra
@@ -39,8 +39,9 @@ spec:
   port: 8080
   scaling: { min: 1, max: 5, targetCPUPercent: 70 }
   domain: ${name}.example            # dev mode rewrites this to sslip.io
-  # database: { engine: postgres, name: ${name}db }   # +highAvailability / +vector (pgvector)
+  # database: { engine: postgres, name: ${name}db }   # +highAvailability / +vector / +expose
   #   engine: mysql -> MariaDB (DATABASE_URL); engine: mongo -> FerretDB (MONGODB_URI)
+  #   expose: true  -> reach the DB on a LAN IP (MetalLB) from workstations
   # storage:  { buckets: [uploads] }
   # queues:   [jobs]
   # secrets:  [chat-model]           # inject a Model endpoint (see: init model)

--- a/examples/hello-web/infra.yaml
+++ b/examples/hello-web/infra.yaml
@@ -14,6 +14,7 @@ spec:
   #   engine: postgres -> +highAvailability: true (failover); +vector: true (pgvector)
   #   engine: mysql    -> MariaDB, injects DATABASE_URL
   #   engine: mongo    -> document store (FerretDB), injects MONGODB_URI
+  #   add expose: true -> reachable on a LAN IP (MetalLB) for workstation access
   # storage:  { buckets: [uploads] }                # -> MINIO_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKETS
   # queues:   [jobs]                                # -> NATS_URL, OPENINFRA_QUEUES
   # secrets:  [hello-extra]                         # -> envFrom that secret (e.g. a Sealed Secret)

--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -552,6 +552,39 @@ spec:
                         {{- end }}
             {{- end }}
             {{- end }}
+            {{- if and $spec.database $spec.database.expose }}
+            ---
+            # --- LAN endpoint: a MetalLB LoadBalancer so workstations on the LAN
+            #     can reach the database directly (psql/GUI/migrations). Consumes
+            #     one pool IP — opt-in via database.expose. Targets the writable
+            #     primary for postgres. ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: db-lan
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: {{ $name }}-db-lan
+                    namespace: {{ $ns }}
+                    labels: { app.kubernetes.io/part-of: {{ $name }} }
+                  spec:
+                    type: LoadBalancer
+                    {{- if eq $dbEngine "mongo" }}
+                    selector: { app.kubernetes.io/name: {{ $name }}-mongo }
+                    ports: [ { port: 27017, targetPort: 27017 } ]
+                    {{- else if eq $dbEngine "mysql" }}
+                    selector: { app.kubernetes.io/name: {{ $name }}-mysql }
+                    ports: [ { port: 3306, targetPort: 3306 } ]
+                    {{- else }}
+                    selector: { cnpg.io/cluster: {{ $name }}-db, cnpg.io/instanceRole: primary }
+                    ports: [ { port: 5432, targetPort: 5432 } ]
+                    {{- end }}
+            {{- end }}
             {{- if and $spec.storage $spec.storage.buckets }}
             ---
             # --- Object storage ("S3"): one Job (aws-cli + kubectl in alpine/k8s)

--- a/platform/abstraction/xrd.yaml
+++ b/platform/abstraction/xrd.yaml
@@ -65,6 +65,10 @@ spec:
                     # postgres only: enable the pgvector extension (vector
                     # similarity search) — pairs with kind: Model for RAG.
                     vector: { type: boolean, default: false }
+                    # Expose the database on a LAN IP (MetalLB LoadBalancer) so
+                    # workstations can reach it directly. Default false = in-cluster
+                    # only (apps connect via the injected URL; admins port-forward).
+                    expose: { type: boolean, default: false }
                 storage:
                   type: object
                   properties:

--- a/ui/src/components/common/db-connectivity.tsx
+++ b/ui/src/components/common/db-connectivity.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { CopyButton } from "@/components/common/copy-button";
+import { useK8sWatch } from "@/hooks/use-k8s-watch";
+import { corePaths } from "@/lib/k8s-paths";
+import type { Service } from "@/types/k8s";
+
+/**
+ * How to reach a database from outside the cluster. Always shows a
+ * `kubectl port-forward` command (works anywhere with kubeconfig). If the DB is
+ * exposed (`database.expose: true` → a `<app>-db-lan` MetalLB LoadBalancer), it
+ * also shows the LAN-reachable host:port.
+ */
+export function DbConnectivity({
+  namespace,
+  internalSvc,
+  lanSvc,
+  port,
+  scheme,
+}: {
+  namespace: string;
+  internalSvc: string;
+  lanSvc: string;
+  port: number;
+  scheme: string;
+}) {
+  const { items } = useK8sWatch<Service>(corePaths.services(namespace));
+  const lan = items.find((s) => s.metadata.name === lanSvc);
+  const lanIp = lan?.status?.loadBalancer?.ingress?.[0]?.ip;
+  const pf = `kubectl port-forward -n ${namespace} svc/${internalSvc} ${port}:${port}`;
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-5">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">From your machine (port-forward)</p>
+          <span className="flex items-center gap-1">
+            <code className="block max-w-full truncate rounded bg-secondary px-2 py-1 text-xs">
+              {pf}
+            </code>
+            <CopyButton value={pf} />
+          </span>
+          <p className="text-xs text-muted-foreground">
+            then connect to{" "}
+            <code className="text-xs">{`${scheme}://…@localhost:${port}`}</code>{" "}
+            — works from any host with kubeconfig access.
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-sm font-medium">LAN endpoint</p>
+          {lanIp ? (
+            <span className="flex items-center gap-1">
+              <code className="rounded bg-secondary px-2 py-1 text-xs text-primary">
+                {lanIp}:{port}
+              </code>
+              <CopyButton value={`${lanIp}:${port}`} />
+            </span>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Not exposed. Set <code className="text-xs">database.expose: true</code>{" "}
+              for a LAN IP (MetalLB LoadBalancer) reachable from workstations.
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/ui/src/features/databases/database-detail-page.tsx
+++ b/ui/src/features/databases/database-detail-page.tsx
@@ -10,6 +10,7 @@ import { CopyButton } from "@/components/common/copy-button";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
 import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DbConnectivity } from "@/components/common/db-connectivity";
 import { DangerZone } from "@/components/common/danger-zone";
 import { LoadingState, ErrorState } from "@/components/common/states";
 import { k8sDelete, k8sGet } from "@/lib/api";
@@ -140,6 +141,15 @@ export function DatabaseDetailPage() {
               </DetailRow>
             </CardContent>
           </Card>
+          <div className="pt-4">
+            <DbConnectivity
+              namespace={namespace}
+              internalSvc={`${name}-rw`}
+              lanSvc={`${appName}-db-lan`}
+              port={5432}
+              scheme="postgresql"
+            />
+          </div>
         </TabsContent>
 
         <TabsContent value="monitoring" className="pt-4">

--- a/ui/src/features/databases/managed-detail-page.tsx
+++ b/ui/src/features/databases/managed-detail-page.tsx
@@ -11,6 +11,7 @@ import { CopyButton } from "@/components/common/copy-button";
 import { YamlViewer } from "@/components/common/yaml-viewer";
 import { GrafanaEmbed } from "@/components/common/grafana-embed";
 import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DbConnectivity } from "@/components/common/db-connectivity";
 import { DangerZone } from "@/components/common/danger-zone";
 import { LoadingState, ErrorState } from "@/components/common/states";
 import { claimHealth } from "@/lib/resource-health";
@@ -37,6 +38,9 @@ const ENGINES = {
     uriLabel: "Connection (MONGODB_URI)",
     consume: "MONGODB_URI (any MongoDB driver)",
     podRe: "(mongo|docdb)",
+    svcSuffix: "-mongo",
+    port: 27017,
+    scheme: "mongodb",
   },
   mysql: {
     label: "MySQL (MariaDB)",
@@ -45,6 +49,9 @@ const ENGINES = {
     uriLabel: "Connection (DATABASE_URL)",
     consume: "DATABASE_URL (any MySQL driver)",
     podRe: "mysql",
+    svcSuffix: "-mysql",
+    port: 3306,
+    scheme: "mysql",
   },
 } as const;
 
@@ -103,6 +110,7 @@ export function ManagedDatabaseDetailPage() {
       <Tabs defaultValue="overview">
         <TabsList>
           <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="connectivity">Connectivity</TabsTrigger>
           <TabsTrigger value="monitoring">Monitoring</TabsTrigger>
           <TabsTrigger value="yaml">YAML</TabsTrigger>
         </TabsList>
@@ -150,6 +158,16 @@ export function ManagedDatabaseDetailPage() {
               </DetailRow>
             </CardContent>
           </Card>
+        </TabsContent>
+
+        <TabsContent value="connectivity" className="pt-4">
+          <DbConnectivity
+            namespace={namespace}
+            internalSvc={`${name}${e.svcSuffix}`}
+            lanSvc={`${name}-db-lan`}
+            port={e.port}
+            scheme={e.scheme}
+          />
         </TabsContent>
 
         <TabsContent value="monitoring" className="pt-4">

--- a/ui/src/features/databases/new-database-dialog.tsx
+++ b/ui/src/features/databases/new-database-dialog.tsx
@@ -54,12 +54,14 @@ export function NewDatabaseDialog({
   const [namespace, setNamespace] = useState(defaultNamespace ?? "default");
   const [engine, setEngine] = useState("postgres");
   const [ha, setHa] = useState(false);
+  const [expose, setExpose] = useState(false);
   const [touched, setTouched] = useState(false);
 
   function reset() {
     setName("");
     setEngine("postgres");
     setHa(false);
+    setExpose(false);
     setTouched(false);
     createMutation.reset();
   }
@@ -89,7 +91,7 @@ export function NewDatabaseDialog({
       kind: "Application",
       metadata: { name, namespace },
       // Data-only Application: just a database, no workload.
-      spec: { database: { engine, name, highAvailability: ha } },
+      spec: { database: { engine, name, highAvailability: ha, expose } },
     } as K8sObject);
   };
 
@@ -184,6 +186,20 @@ export function NewDatabaseDialog({
                   : engine === "mysql"
                     ? "Not available for MySQL yet (single instance)"
                     : "Primary + standby, auto-failover"}
+              </span>
+            </label>
+          </div>
+          <div className="space-y-1.5">
+            <Label>LAN access</Label>
+            <label className="flex h-9 items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={expose}
+                onChange={(e) => setExpose(e.target.checked)}
+                className="size-4 accent-primary"
+              />
+              <span className="text-muted-foreground">
+                Expose on a LAN IP (MetalLB) for workstation access
               </span>
             </label>
           </div>


### PR DESCRIPTION
## What

Cluster DB endpoints (`<name>-db-rw.<ns>.svc…`) only resolve inside the cluster, so LAN workstations can't connect (the `getaddrinfo failed` you hit). This adds an **opt-in** way to reach a database from the LAN — the RDS-endpoint analog.

```yaml
database:
  engine: postgres
  name: shopdb
  expose: true     # -> a MetalLB LoadBalancer (LAN IP) for the DB
```

## How

- **XRD**: `database.expose` (bool, default `false` — in-cluster only by default).
- **Composition**: when set, a `LoadBalancer` Service `<name>-db-lan` gets a MetalLB LAN IP. It targets the **writable primary** for postgres (`cnpg.io/instanceRole: primary`), or the MariaDB/FerretDB Service for mysql/mongo. One pool IP per exposed DB (opt-in keeps the pool sane).
- **Console**: a **Connectivity** panel on the postgres + managed (mongo/mysql) detail pages — always shows a copyable `kubectl port-forward` command (works from any host with kubeconfig), and the **LAN `host:port`** once exposed. The New Database dialog gains an **"Expose on LAN"** toggle.
- Example + CLI scaffolds document `expose`.

## Testing
- Composition rendered offline across postgres/mysql/mongo **+expose**: emits the LoadBalancer with the correct per-engine selector; absent when not exposed.
- `kubectl apply --dry-run=server` (XRD + Composition); `tsc` + `npm run build` green.
- MetalLB pool has 9 spare IPs (.242–.250).

After merge I'll demo it live (flip `expose` on a DB, confirm the MetalLB IP, connect from a LAN host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)