### PR TITLE
fix(storage): make MinIO HA opt-in (default standalone)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -62,6 +62,10 @@ edge:
 storage:
   # Fast local NVMe (RWO) for databases. k3s local-path. NEVER put DBs on CIFS/NFS.
   databaseStorageClass: local-path
+  # MinIO object storage topology. false = standalone (default; fine for dev /
+  # single node). true = distributed HA (4 erasure-coded drives across nodes;
+  # needs >=4 drives). Not defaulted to HA — opt in deliberately.
+  highAvailability: false
   # NAS-backed shared/bulk volumes (RWX). Point at an SMB/NFS export.
   shared:
     enabled: false

--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ excl() {
     LOG "component disabled: $1"
   fi
 }
-excl minio         "storage/minio.yaml"
+excl minio         "storage/minio.yaml,storage/minio-ha.yaml"
 excl cloudnativePG "data/cloudnativepg.yaml"
 excl nats          "data/nats.yaml"
 excl redis         "data/redis.yaml"
@@ -77,6 +77,18 @@ excl console       "console/*"
 excl serverless    "serverless/*"
 excl gpu           "gpu/*"
 excl velero        "backup/*"
+
+# MinIO topology: standalone (storage/minio.yaml) by default; HA selects the
+# distributed variant (storage/minio-ha.yaml). Exactly one is included — we do
+# NOT default to HA. (Skip when MinIO is disabled — both already excluded above.)
+if [ "$(yget components.minio)" != "false" ]; then
+  if [ "$(yget storage.highAvailability)" = "true" ]; then
+    EXCLUDES="${EXCLUDES},storage/minio.yaml"
+    LOG "storage: MinIO HA (distributed)"
+  else
+    EXCLUDES="${EXCLUDES},storage/minio-ha.yaml"
+  fi
+fi
 case "$EXCLUDES" in *,*) EXCLUDE_GLOB="{${EXCLUDES}}";; *) EXCLUDE_GLOB="$EXCLUDES";; esac
 
 LOG "mode=$MODE cluster=$CLUSTER_NAME k3s=$K3S_CHANNEL"

--- a/platform/root-app.yaml
+++ b/platform/root-app.yaml
@@ -20,7 +20,9 @@ spec:
       # Raw CRs (e.g. abstraction/config/*) are synced by their own child app.
       include: '{networking,storage,data,observability,security,abstraction,console,gpu,serverless,backup}/*.yaml'
       # Nested manifests/ dirs are deployed by their own child app (e.g. the
-      # console), not applied directly by the root app.
+      # console), not applied directly by the root app. install.sh rewrites this
+      # glob to also drop disabled components and the unused MinIO variant
+      # (storage/minio.yaml vs storage/minio-ha.yaml — exactly one is included).
       exclude: '**/manifests/**'
   destination:
     server: https://kubernetes.default.svc

--- a/platform/storage/minio-ha.yaml
+++ b/platform/storage/minio-ha.yaml
@@ -1,0 +1,47 @@
+# MinIO (HA variant) — distributed object storage. Selected by install.sh when
+# config.yaml `storage.highAvailability: true`; otherwise storage/minio.yaml
+# (standalone) is used. Exactly one of the two is included in the app-of-apps.
+#
+# Distributed = 4 erasure-coded drives across nodes; survives a single node loss.
+# Needs >=4 drives (one node holds 2 on a 3-node cluster). NOT for single-node dev.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: minio
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://charts.min.io/
+    chart: minio
+    targetRevision: 5.2.0
+    helm:
+      values: |
+        mode: distributed
+        replicas: 4
+        persistence:
+          enabled: true
+          size: 20Gi
+          # storageClass left default; for NAS reuse, bind a pre-made PV instead.
+        resources:
+          requests: { memory: 512Mi }
+        # Spread drives across nodes so a node loss doesn't take out a quorum.
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels: { app: minio }
+        # Root creds come from a Sealed Secret in prod; chart default for dev only.
+        consoleService:
+          type: ClusterIP
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: minio
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions: [CreateNamespace=true]

--- a/platform/storage/minio.yaml
+++ b/platform/storage/minio.yaml
@@ -16,27 +16,18 @@ spec:
     targetRevision: 5.2.0
     helm:
       values: |
-        # Distributed (HA): 4 erasure-coded drives across nodes. Survives a
-        # single node loss (EC tolerates losing up to half the drives). On a
-        # 3-node cluster one node holds 2 drives. For single-node dev, set
-        # mode: standalone + replicas: 1.
-        mode: distributed
-        replicas: 4
+        # Standalone (default) — one instance, fine for dev/single-node. For HA
+        # set config.yaml `storage.highAvailability: true`; install.sh then
+        # selects storage/minio-ha.yaml (distributed, 4 erasure-coded drives)
+        # instead of this file. We don't default to HA.
+        mode: standalone
+        replicas: 1
         persistence:
           enabled: true
-          size: 20Gi
+          size: 50Gi
           # storageClass left default; for NAS reuse, bind a pre-made PV instead.
         resources:
           requests: { memory: 512Mi }
-        # Spread drives across nodes so a node loss doesn't take out a quorum.
-        affinity:
-          podAntiAffinity:
-            preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 100
-                podAffinityTerm:
-                  topologyKey: kubernetes.io/hostname
-                  labelSelector:
-                    matchLabels: { app: minio }
         # Root creds come from a Sealed Secret in prod; chart default for dev only.
         consoleService:
           type: ClusterIP


### PR DESCRIPTION
## Why

PR #38 set MinIO to **distributed unconditionally** — it *assumed* HA for everyone (and would force 4 MinIO pods on a single-node dev box). HA should be a deliberate opt-in, consistent with databases (whose `highAvailability` already defaults false).

## How

Two variants + a config flag (same shape as the existing component toggles):
- **`storage/minio.yaml`** → **standalone** (dev-safe default).
- **`storage/minio-ha.yaml`** → **distributed** (4 erasure-coded drives — the spec we've been running).
- **`install.sh`** reads `storage.highAvailability` (default `false`) and includes **exactly one** variant via the app-of-apps exclude glob. If MinIO is disabled entirely, both are excluded.
- `config.example.yaml` documents the flag; `root-app.yaml` notes the selection.

## Testing
- `bash -n install.sh` clean; exclude logic verified for HA true/false.
- Both MinIO manifests pass `kubectl apply --dry-run=server`.

## Live cluster
This cluster stays on **distributed** (we want HA here): after merge I'll point its root-app at the HA variant + set its config flag. Demo data only, so the transition is low-stakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)