### PR TITLE
feat(db): MySQL high availability via mariadb-operator (Galera)

### DIFF
--- a/cli/open-infra
+++ b/cli/open-infra
@@ -40,7 +40,7 @@ spec:
   scaling: { min: 1, max: 5, targetCPUPercent: 70 }
   domain: ${name}.example            # dev mode rewrites this to sslip.io
   # database: { engine: postgres, name: ${name}db }   # +highAvailability / +vector / +expose
-  #   engine: mysql -> MariaDB (DATABASE_URL); engine: mongo -> FerretDB (MONGODB_URI)
+  #   engine: mysql -> MariaDB (DATABASE_URL; +highAvailability -> Galera); mongo -> FerretDB
   #   expose: true  -> reach the DB on a LAN IP (MetalLB) from workstations
   # storage:  { buckets: [uploads] }
   # queues:   [jobs]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -91,6 +91,7 @@ components:
   # this into the app-of-apps include path.
   minio: true                  # object storage (S3)
   cloudnativePG: true          # managed Postgres (RDS)
+  mariadbOperator: true        # managed MySQL/MariaDB (RDS MySQL) — engine: mysql
   nats: true                   # queues / JetStream (SQS/SNS)
   redis: true                  # cache
   observability: true          # kube-prometheus-stack + Loki + Grafana

--- a/examples/hello-web/infra.yaml
+++ b/examples/hello-web/infra.yaml
@@ -12,7 +12,7 @@ spec:
   # Uncomment any of these — the platform provisions them and injects creds:
   # database: { engine: postgres, name: hellodb }   # -> DATABASE_URL
   #   engine: postgres -> +highAvailability: true (failover); +vector: true (pgvector)
-  #   engine: mysql    -> MariaDB, injects DATABASE_URL
+  #   engine: mysql    -> MariaDB (operator); +highAvailability: true -> Galera 3-node
   #   engine: mongo    -> document store (FerretDB), injects MONGODB_URI
   #   add expose: true -> reachable on a LAN IP (MetalLB) for workstation access
   # storage:  { buckets: [uploads] }                # -> MINIO_ENDPOINT/ACCESS_KEY/SECRET_KEY/BUCKETS

--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,7 @@ excl console       "console/*"
 excl serverless    "serverless/*"
 excl gpu           "gpu/*"
 excl velero        "backup/*"
+excl mariadbOperator "data/mariadb-operator.yaml"
 
 # MinIO topology: standalone (storage/minio.yaml) by default; HA selects the
 # distributed variant (storage/minio-ha.yaml). Exactly one is included — we do

--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -413,8 +413,10 @@ spec:
                     ports: [ { port: 27017, targetPort: 27017 } ]
             {{- else if eq $dbEngine "mysql" }}
             ---
-            # --- Relational ("RDS MySQL"): MariaDB (MySQL wire protocol, GPLv2).
-            #     Self-contained Deployment + PVC, single instance for now. ---
+            # --- Relational ("RDS MySQL"): MariaDB via mariadb-operator (GPLv2 /
+            #     operator MIT). highAvailability -> 3-node Galera (synchronous,
+            #     auto-recovery); else a single instance. The operator owns the
+            #     StatefulSet + Services (primary svc is <name>-mysql). ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
             kind: Object
             metadata:
@@ -433,24 +435,8 @@ spec:
                     database: "{{ $dbName }}"
                     DATABASE_URL: "mysql://app:{{ $dbPass }}@{{ $name }}-mysql.{{ $ns }}.svc.cluster.local:3306/{{ $dbName }}"
             ---
-            # MariaDB data volume (local NVMe).
-            apiVersion: kubernetes.crossplane.io/v1alpha2
-            kind: Object
-            metadata:
-              annotations:
-                gotemplating.fn.crossplane.io/composition-resource-name: mysql-pvc
-            spec:
-              forProvider:
-                manifest:
-                  apiVersion: v1
-                  kind: PersistentVolumeClaim
-                  metadata: { name: {{ $name }}-mysql-data, namespace: {{ $ns }} }
-                  spec:
-                    accessModes: [ReadWriteOnce]
-                    storageClassName: local-path
-                    resources: { requests: { storage: 5Gi } }
-            ---
-            # MariaDB server.
+            # MariaDB (operator CR). Operator provisions the StatefulSet, user,
+            # database, and Services from these refs.
             apiVersion: kubernetes.crossplane.io/v1alpha2
             kind: Object
             metadata:
@@ -459,59 +445,26 @@ spec:
             spec:
               forProvider:
                 manifest:
-                  apiVersion: apps/v1
-                  kind: Deployment
-                  metadata:
-                    name: {{ $name }}-mysql
-                    namespace: {{ $ns }}
-                    labels: { app.kubernetes.io/name: {{ $name }}-mysql }
-                  spec:
-                    replicas: 1
-                    strategy: { type: Recreate }
-                    selector: { matchLabels: { app.kubernetes.io/name: {{ $name }}-mysql } }
-                    template:
-                      metadata: { labels: { app.kubernetes.io/name: {{ $name }}-mysql } }
-                      spec:
-                        containers:
-                          - name: mariadb
-                            image: mariadb:11
-                            env:
-                              - name: MARIADB_ROOT_PASSWORD
-                                valueFrom: { secretKeyRef: { name: {{ $name }}-mysql-app, key: rootPassword } }
-                              - name: MARIADB_DATABASE
-                                valueFrom: { secretKeyRef: { name: {{ $name }}-mysql-app, key: database } }
-                              - name: MARIADB_USER
-                                valueFrom: { secretKeyRef: { name: {{ $name }}-mysql-app, key: username } }
-                              - name: MARIADB_PASSWORD
-                                valueFrom: { secretKeyRef: { name: {{ $name }}-mysql-app, key: password } }
-                            ports: [ { containerPort: 3306 } ]
-                            resources:
-                              requests: { cpu: 100m, memory: 256Mi }
-                              limits: { cpu: "2", memory: 1Gi }
-                            volumeMounts: [ { name: data, mountPath: /var/lib/mysql } ]
-                            readinessProbe:
-                              exec: { command: ["healthcheck.sh", "--connect", "--innodb_initialized"] }
-                              initialDelaySeconds: 15
-                              periodSeconds: 10
-                        volumes:
-                          - name: data
-                            persistentVolumeClaim: { claimName: {{ $name }}-mysql-data }
-            ---
-            # MariaDB Service — the MySQL endpoint apps connect to (3306).
-            apiVersion: kubernetes.crossplane.io/v1alpha2
-            kind: Object
-            metadata:
-              annotations:
-                gotemplating.fn.crossplane.io/composition-resource-name: mysql-svc
-            spec:
-              forProvider:
-                manifest:
-                  apiVersion: v1
-                  kind: Service
+                  apiVersion: k8s.mariadb.com/v1alpha1
+                  kind: MariaDB
                   metadata: { name: {{ $name }}-mysql, namespace: {{ $ns }} }
                   spec:
-                    selector: { app.kubernetes.io/name: {{ $name }}-mysql }
-                    ports: [ { port: 3306, targetPort: 3306 } ]
+                    rootPasswordSecretKeyRef: { name: {{ $name }}-mysql-app, key: rootPassword }
+                    username: app
+                    passwordSecretKeyRef: { name: {{ $name }}-mysql-app, key: password }
+                    database: {{ $dbName }}
+                    port: 3306
+                    replicas: {{ if $spec.database.highAvailability }}3{{ else }}1{{ end }}
+                    {{- if $spec.database.highAvailability }}
+                    galera:
+                      enabled: true
+                    {{- end }}
+                    storage:
+                      size: 5Gi
+                      storageClassName: local-path
+                    resources:
+                      requests: { cpu: 100m, memory: 256Mi }
+                      limits: { cpu: "2", memory: 1Gi }
             {{- else }}
             ---
             # --- Managed Postgres ("RDS") via CloudNativePG. LOCAL NVMe only. ---
@@ -578,7 +531,7 @@ spec:
                     selector: { app.kubernetes.io/name: {{ $name }}-mongo }
                     ports: [ { port: 27017, targetPort: 27017 } ]
                     {{- else if eq $dbEngine "mysql" }}
-                    selector: { app.kubernetes.io/name: {{ $name }}-mysql }
+                    selector: { app.kubernetes.io/instance: {{ $name }}-mysql, app.kubernetes.io/name: mariadb }
                     ports: [ { port: 3306, targetPort: 3306 } ]
                     {{- else }}
                     selector: { cnpg.io/cluster: {{ $name }}-db, cnpg.io/instanceRole: primary }

--- a/platform/data/mariadb-operator.yaml
+++ b/platform/data/mariadb-operator.yaml
@@ -1,0 +1,31 @@
+# mariadb-operator — manages MariaDB (incl. Galera HA) via CRDs. MIT licensed.
+# Powers the Application abstraction's `database: { engine: mysql }`:
+#   - single instance by default
+#   - Galera (3-node synchronous, auto-recovery) when highAvailability: true
+# CRDs are installed as a subchart (crds.enabled).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mariadb-operator
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: default
+  source:
+    repoURL: https://mariadb-operator.github.io/mariadb-operator
+    chart: mariadb-operator
+    targetRevision: 26.6.0
+    helm:
+      values: |
+        crds:
+          enabled: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mariadb-operator
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions:
+      - CreateNamespace=true
+      # CRDs are large — server-side apply avoids the 256KB annotation limit.
+      - ServerSideApply=true

--- a/ui/src/features/databases/managed-detail-page.tsx
+++ b/ui/src/features/databases/managed-detail-page.tsx
@@ -126,8 +126,10 @@ export function ManagedDatabaseDetailPage() {
               <DetailRow label="Namespace">{namespace}</DetailRow>
               <DetailRow label="Application">{name}</DetailRow>
               <DetailRow label="High availability">
-                {engineKey === "mongo" && ha
-                  ? "On · 2 FerretDB replicas (proxy tier)"
+                {ha
+                  ? engineKey === "mongo"
+                    ? "On · 2 FerretDB replicas (proxy tier)"
+                    : "On · Galera 3-node cluster"
                   : "Off (single instance)"}
               </DetailRow>
               <DetailRow label={e.uriLabel}>

--- a/ui/src/features/databases/new-database-dialog.tsx
+++ b/ui/src/features/databases/new-database-dialog.tsx
@@ -147,13 +147,7 @@ export function NewDatabaseDialog({
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="db-engine">Engine</Label>
-            <Select
-              value={engine}
-              onValueChange={(v) => {
-                setEngine(v);
-                if (v === "mysql") setHa(false); // HA n/a for MySQL
-              }}
-            >
+            <Select value={engine} onValueChange={setEngine}>
               <SelectTrigger id="db-engine">
                 <SelectValue placeholder="Engine" />
               </SelectTrigger>
@@ -169,22 +163,15 @@ export function NewDatabaseDialog({
             <label className="flex h-9 items-center gap-2 text-sm">
               <input
                 type="checkbox"
-                checked={ha && engine !== "mysql"}
-                disabled={engine === "mysql"}
+                checked={ha}
                 onChange={(e) => setHa(e.target.checked)}
-                className="size-4 accent-primary disabled:opacity-50"
+                className="size-4 accent-primary"
               />
-              <span
-                className={
-                  engine === "mysql"
-                    ? "text-muted-foreground/60"
-                    : "text-muted-foreground"
-                }
-              >
+              <span className="text-muted-foreground">
                 {engine === "mongo"
                   ? "2 FerretDB replicas (proxy tier)"
                   : engine === "mysql"
-                    ? "Not available for MySQL yet (single instance)"
+                    ? "Galera 3-node cluster (synchronous)"
                     : "Primary + standby, auto-failover"}
               </span>
             </label>


### PR DESCRIPTION
## What

MySQL was a single self-contained MariaDB Deployment (no HA — the gap you flagged). This makes `engine: mysql` **operator-managed**, so `highAvailability` works:

```yaml
database:
  engine: mysql
  name: shopdb
  highAvailability: true   # -> 3-node Galera (synchronous, auto-recovery)
```

## How

- **`platform/data/mariadb-operator.yaml`** — installs the **mariadb-operator** (MIT; chart `26.6.0`, CRDs as a subchart, ServerSideApply). New component toggle `mariadbOperator` (default on).
- **Composition**: the mysql branch now renders a **`MariaDB` CR** (operator) instead of a raw Deployment. `highAvailability: true` → `replicas: 3` + `galera.enabled` (synchronous multi-primary, auto-recovery); else a single instance. The operator owns the StatefulSet + Services, and the **primary Service is still `<name>-mysql`**, so the injected `DATABASE_URL` is unchanged.
- **LAN expose**: the `db-lan` selector for mysql now matches the operator's pod labels.
- **Console**: re-enabled the HA toggle for MySQL (New Database dialog) and the managed-db detail shows "Galera 3-node".

## Testing
- Installed the operator **live** and validated it: a single `MariaDB` CR came up Ready and served the app user/database.
- Composition rendered offline for single + HA — valid YAML; the **Galera MariaDB CR passed the operator's admission webhook** (server dry-run).
- `tsc` + `npm run build` green.

## Notes
- The operator is already running on this cluster (installed during validation); Argo adopts it on merge. No existing mysql DBs to migrate.
- Galera needs ≥3 nodes (we have 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)