### PR TITLE
feat(console): selectable refresh interval on Grafana embeds

### DIFF
--- a/ui/src/components/common/grafana-embed.tsx
+++ b/ui/src/components/common/grafana-embed.tsx
@@ -1,9 +1,20 @@
+import { useState } from "react";
 import { useConfig } from "@/lib/config-context";
 import { EmptyState } from "@/components/common/states";
+
+// Auto-refresh choices for the embed — from near-live up to 2 minutes.
+const REFRESH_OPTIONS = [
+  { label: "Live (5s)", value: "5s" },
+  { label: "10s", value: "10s" },
+  { label: "30s", value: "30s" },
+  { label: "1m", value: "1m" },
+  { label: "2m", value: "2m" },
+];
 
 /**
  * Embeds a Grafana dashboard (kiosk mode) via the same-origin /grafana proxy.
  * `vars` become Grafana template variables, e.g. { "var-namespace": "ai" }.
+ * A picker controls the panel auto-refresh interval (live → 2m).
  */
 export function GrafanaEmbed({
   uid,
@@ -15,6 +26,7 @@ export function GrafanaEmbed({
   height?: number;
 }) {
   const { grafanaBaseUrl } = useConfig();
+  const [refresh, setRefresh] = useState("30s");
   const base = grafanaBaseUrl?.trim().replace(/\/+$/, "");
   if (!base) {
     return (
@@ -27,17 +39,41 @@ export function GrafanaEmbed({
   const params = new URLSearchParams({
     orgId: "1",
     theme: "dark",
-    refresh: "30s",
+    refresh,
     ...(vars ?? {}),
   });
   // Bare `kiosk` (not kiosk=) hides Grafana's nav/top bar.
   const src = `${base}/d/${uid}?${params.toString()}&kiosk`;
   return (
-    <iframe
-      src={src}
-      title="Grafana dashboard"
-      className="w-full rounded-md border border-border"
-      style={{ height }}
-    />
+    <div className="space-y-2">
+      <div className="flex items-center justify-end gap-2">
+        <label
+          htmlFor={`refresh-${uid}`}
+          className="text-xs text-muted-foreground"
+        >
+          Auto-refresh
+        </label>
+        <select
+          id={`refresh-${uid}`}
+          value={refresh}
+          onChange={(e) => setRefresh(e.target.value)}
+          className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+        >
+          {REFRESH_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <iframe
+        // key forces a reload when the refresh interval changes.
+        key={refresh}
+        src={src}
+        title="Grafana dashboard"
+        className="w-full rounded-md border border-border"
+        style={{ height }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
Closes #36. The Grafana metric embeds hardcoded a 30s refresh; this adds an **Auto-refresh** picker (Live 5s / 10s / 30s / 1m / 2m) shown on every embed (Model / Function / Database / managed-DB Monitoring tabs). Changing it reloads the panel at the selected interval via the Grafana `refresh` param.

- `useState` is placed before the "no Grafana configured" early return so hook order is stable.
- `tsc` + `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)