### PR TITLE
feat(vm): kind: VirtualMachine (EC2) — KubeVirt VMs, console, Windows pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ CNCF projects — not a reinvention of databases or storage.
 | ElastiCache | cache | Redis |
 | Lambda | serverless (`kind: Function`) | Knative — scale-to-zero |
 | Bedrock | managed inference (`kind: Model`) | Ollama on GPU + NVIDIA device plugin |
+| EC2 | virtual machines (`kind: VirtualMachine`) | KubeVirt + CDI (Linux + Windows) |
 | CloudFormation | the manifest | `infra.yaml` → Crossplane |
 | CloudWatch | metrics/logs | Prometheus + Grafana + Loki |
 | Secrets Manager | secrets | Sealed Secrets |
@@ -143,7 +144,7 @@ the endpoint — is in [`docs/gpu.md`](docs/gpu.md).
 **Validated on a live 3-node cluster (2 with GPUs).** One `install.sh` stands up
 k3s + MetalLB + Argo CD; the app-of-apps reconciles the platform (cert-manager,
 MinIO, CloudNativePG, NATS, Redis, kube-prometheus-stack + Loki, Sealed Secrets,
-Knative, Velero). The three public abstractions are shipped and verified
+Knative, Velero, KubeVirt). The four public abstractions are shipped and verified
 end-to-end:
 
 - **`Application`** — Deployment/Service/Ingress/HPA, plus managed databases
@@ -151,6 +152,9 @@ end-to-end:
   quotas, limits, and NetworkPolicies.
 - **`Model`** — GPU-backed, OpenAI-compatible inference (open-infra's "Bedrock").
 - **`Function`** — Knative scale-to-zero serverless (open-infra's "Lambda").
+- **`VirtualMachine`** — real VMs via KubeVirt (open-infra's "EC2"): an OS
+  catalog (Linux + Windows), persistent disk, SSH/RDP. See
+  [`docs/virtual-machines.md`](docs/virtual-machines.md).
 
 The build history and phase plan live in [`docs/roadmap.md`](docs/roadmap.md).
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -101,3 +101,4 @@ components:
   serverless: true             # Knative — kind: Function, scale-to-zero
   gpu: true                    # NVIDIA device plugin + DCGM metrics (GPU nodes only)
   velero: true                 # scheduled backups → MinIO (node-agent fs backups)
+  virtualization: true         # KubeVirt + CDI — kind: VirtualMachine (EC2-style VMs); needs /dev/kvm

--- a/docs/virtual-machines.md
+++ b/docs/virtual-machines.md
@@ -1,0 +1,130 @@
+# Virtual Machines (`kind: VirtualMachine`)
+
+open-infra's **EC2**: a real virtual machine on the cluster, backed by
+[KubeVirt](https://kubevirt.io) (VMs on Kubernetes) and
+[CDI](https://github.com/kubevirt/containerized-data-importer) (disk imaging).
+Pick an OS, get a persistent disk, first-boot login, and native access (SSH for
+Linux, RDP for Windows).
+
+## Requirements
+
+- **Hardware virtualization** (`/dev/kvm`) on the nodes — Intel VT-x or AMD-V.
+  Check: `grep -oE 'vmx|svm' /proc/cpuinfo` on each node should print something.
+- `components.virtualization: true` in `config.yaml` (default). `install.sh`
+  installs KubeVirt + CDI from the upstream release manifests.
+
+## Quick start
+
+```yaml
+# infra.yaml
+apiVersion: openinfra.dev/v1
+kind: VirtualMachine
+metadata:
+  name: dev-box
+spec:
+  os: ubuntu-24.04          # see the catalog below
+  cpu: 2
+  memory: 4Gi
+  diskSize: 30Gi
+  sshKey: "ssh-ed25519 AAAA…"   # Linux login (omit -> generated password)
+  expose: false             # true -> SSH/RDP on a LAN IP (MetalLB)
+```
+
+```sh
+./cli/open-infra deploy        # or: create it from the console's "New VM"
+```
+
+The platform imports the OS image to a persistent disk (CDI), boots it on
+KubeVirt, and creates a connection `Secret` (`<name>-vm`) with the login. The
+console's **Virtual Machines** page shows status/IP, the credentials, Start/Stop,
+and how to connect.
+
+## The OS catalog
+
+| `os` | Family | Source |
+|---|---|---|
+| `ubuntu-24.04`, `ubuntu-22.04` | Linux | cloud image (containerdisk), imported by CDI |
+| `fedora-40` | Linux | cloud image |
+| `debian-12` | Linux | cloud image |
+| `centos-stream-9` | Linux | cloud image |
+| `windows` | Windows | **clones a golden image you build once** (see below) |
+
+The catalog lives in two places that must stay in sync: the XRD enum
+(`platform/abstraction/vm-xrd.yaml`) and the Composition's `$catalog`
+(`platform/abstraction/vm-composition.yaml`). The console mirrors it in
+`ui/src/features/vms/vm-shared.ts`.
+
+## Access
+
+- **Linux** — SSH as `openinfra`. Your `sshKey` is installed via cloud-init; a
+  generated password is also set (revealable on the VM page) as a fallback.
+- **Windows** — RDP as `Administrator` with a generated password (revealable on
+  the VM page). Connect with `mstsc /v:<host>:3389`.
+- **`expose: true`** publishes a `LoadBalancer` (MetalLB) so workstations on the
+  LAN can reach SSH (22) / RDP (3389) directly. Otherwise use
+  `kubectl port-forward svc/<name> <port>:<port>`.
+
+Power: the console's **Start/Stop** flips `spec.running`, which the Composition
+maps to KubeVirt `runStrategy` (`Always`/`Halted`). The disk is retained while
+stopped.
+
+> Web (in-browser) console is intentionally **not** provided — access is native
+> SSH / RDP, so there is no extra in-cluster console dependency to run.
+
+## Windows: build the golden image once
+
+Windows has no redistributable cloud image, so you build a reusable **golden
+image** once from a Microsoft **evaluation ISO**, then every `os: windows` VM
+clones it (fast). This is a one-time, operator-run step.
+
+### Licensing (read this)
+
+- **Evaluation editions are free and legal for testing/non-production only.**
+  Windows Server eval = 180 days; Windows 10/11 Enterprise eval = 90 days.
+  Download from the [Microsoft Evaluation Center](https://www.microsoft.com/evalcenter).
+- **Production Windows VDI/desktops require Microsoft licensing** (VDA / Windows
+  Enterprise E3+ / RDS CALs). open-infra does not and cannot provide that — it is
+  not open source. Linux VMs have no such constraint.
+
+### Build it
+
+```sh
+# 1. Get an eval ISO from the Microsoft Evaluation Center (e.g. Windows Server
+#    2022) and note its path or a URL the cluster can reach.
+# 2. Run the builder (needs genisoimage/mkisofs locally):
+scripts/build-windows-image.sh \
+  --windows-iso https://software-static.download.../SERVER_EVAL_x64.iso \
+  --name windows-golden
+```
+
+The script (see `scripts/build-windows-image.sh`):
+
+1. Creates the `openinfra-images` namespace and a blank target `DataVolume`.
+2. Imports the Windows ISO and the latest **virtio-win** ISO via CDI.
+3. Builds a small `autounattend` ISO from `scripts/windows/autounattend.xml`
+   (unattended install + virtio storage driver + `SetupComplete.cmd`).
+4. Boots an installer VM that runs Windows Setup unattended; `SetupComplete.cmd`
+   installs **cloudbase-init** (consumes the per-VM cloud-init: sets the
+   `Administrator` password + enables RDP), installs the **virtio guest tools**
+   and **qemu-guest-agent**, then runs `sysprep /generalize /oobe /shutdown`.
+5. On shutdown, the target disk is your golden image — kept as the
+   `windows-golden` PVC in `openinfra-images`. Delete the installer VM.
+
+After that, `spec.os: windows` works like any other VM (the Composition clones
+`windows-golden`).
+
+> The answer file targets **Windows Server 2022**. Other versions
+> (Windows 11, Server 2025) may need edition-index or driver-path tweaks in
+> `autounattend.xml`.
+
+## Troubleshooting
+
+- **Disk stuck importing** — watch CDI: `kubectl get datavolume -n <ns> <name>-root -w`.
+  First import of an OS pulls the cloud image (hundreds of MB); later VMs of the
+  same OS reuse the CDI image cache.
+- **VM Pending, never Running** — confirm `/dev/kvm` on the node and that
+  KubeVirt is `Deployed`: `kubectl get kubevirt -n kubevirt`.
+- **No IP shown** — the guest agent reports the IP; Linux installs
+  `qemu-guest-agent` via cloud-init on first boot (give it a minute).
+- **Windows VM won't boot** — the `windows-golden` PVC must exist in
+  `openinfra-images`. Build it first (above).

--- a/examples/vm/infra.yaml
+++ b/examples/vm/infra.yaml
@@ -1,0 +1,24 @@
+# A virtual machine (open-infra's EC2). The platform imports the OS image to a
+# persistent disk (CDI), boots it on KubeVirt, injects your login, and gives you
+# a web VNC console + SSH (Linux) / RDP (Windows).
+#
+#   ./cli/open-infra deploy        # from this directory
+#
+apiVersion: openinfra.dev/v1
+kind: VirtualMachine
+metadata:
+  name: dev-box
+spec:
+  # Curated OS catalog:
+  #   ubuntu-24.04 · ubuntu-22.04 · fedora-40 · debian-12 · centos-stream-9
+  #   windows   (clones a golden image you build once — see docs/virtual-machines.md)
+  os: ubuntu-24.04
+  cpu: 2
+  memory: 4Gi
+  diskSize: 30Gi
+  # Linux login. Omit to use the generated password (revealable in the console).
+  sshKey: "ssh-ed25519 AAAA...replace-with-your-public-key"
+  # true -> reachable on a LAN IP (MetalLB): SSH (22) for Linux, RDP (3389) for
+  # Windows. Off -> use the web VNC console or `kubectl port-forward`.
+  expose: false
+  # running: false   # power off (disk retained); the console's Start/Stop flips this

--- a/install.sh
+++ b/install.sh
@@ -133,6 +133,24 @@ EOF
   fi
 fi
 
+# ── 2b. KubeVirt + CDI (VMs) ─────────────────────────────────
+# Cluster virtualization for the kind: VirtualMachine (EC2) abstraction. Installed
+# from upstream release manifests (like MetalLB), not Argo. Needs hardware virt
+# (/dev/kvm) on the nodes. The abstraction's XRD/Composition ship with Crossplane.
+if [ "$(yget components.virtualization)" = "false" ]; then
+  LOG "component disabled: virtualization (KubeVirt/CDI)"
+else
+  KUBEVIRT_VERSION="v1.8.4"; CDI_VERSION="v1.65.0"
+  LOG "installing KubeVirt ${KUBEVIRT_VERSION} + CDI ${CDI_VERSION} (VMs)…"
+  RUN "$KUBECTL apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
+  RUN "$KUBECTL apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml"
+  RUN "$KUBECTL apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-operator.yaml"
+  RUN "$KUBECTL apply -f https://github.com/kubevirt/containerized-data-importer/releases/download/${CDI_VERSION}/cdi-cr.yaml"
+  RUN "$KUBECTL -n kubevirt wait --for=condition=Available kubevirt/kubevirt --timeout=300s || true"
+  # Holds the golden Windows image (cloned per-VM). Created empty; see docs.
+  RUN "$KUBECTL create namespace openinfra-images --dry-run=client -o yaml | $KUBECTL apply -f -"
+fi
+
 # ── 3. Argo CD ───────────────────────────────────────────────
 LOG "installing Argo CD…"
 RUN "$KUBECTL create namespace argocd --dry-run=client -o yaml | $KUBECTL apply -f -"

--- a/platform/abstraction/provider-setup.yaml
+++ b/platform/abstraction/provider-setup.yaml
@@ -49,6 +49,15 @@ rules:
   - apiGroups: [batch]
     resources: [jobs]
     verbs: [get, list, watch, create, update, patch, delete]
+  # VirtualMachines for the kind: VirtualMachine (EC2) abstraction. KubeVirt's own
+  # controller creates the backing DataVolume/VMI from dataVolumeTemplates, so the
+  # provider only manages the VirtualMachine itself (datavolumes listed for safety).
+  - apiGroups: [kubevirt.io]
+    resources: [virtualmachines, virtualmachineinstances]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [cdi.kubevirt.io]
+    resources: [datavolumes]
+    verbs: [get, list, watch, create, update, patch, delete]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/platform/abstraction/vm-composition.yaml
+++ b/platform/abstraction/vm-composition.yaml
@@ -1,0 +1,256 @@
+# The compiler for kind: VirtualMachine -> a KubeVirt VirtualMachine with a
+# persistent CDI disk (cloud image for Linux, a cloned golden image for Windows),
+# first-boot config (cloud-init for Linux, cloudbase-init PowerShell for Windows),
+# a Service, a connection Secret (<name>-vm: USERNAME/PASSWORD/HOST/PORT/ACCESS),
+# and an optional LAN LoadBalancer (SSH 22 / RDP 3389).
+#
+# OS image + type come from a curated catalog ($catalog below, in sync with the
+# XRD enum). The login password is derived deterministically from the composite's
+# UID so it is stable across reconciles. Power state (spec.running) maps to
+# runStrategy so the console can Start/Stop without the provider reverting it.
+#
+# Synced after the XRD (sync-wave 3).
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: vm
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  compositeTypeRef:
+    apiVersion: openinfra.dev/v1
+    kind: XVirtualMachine
+  mode: Pipeline
+  pipeline:
+    - step: render-resources
+      functionRef:
+        name: crossplane-contrib-function-go-templating
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{- $spec := .observed.composite.resource.spec }}
+            {{- $labels := .observed.composite.resource.metadata.labels | default dict }}
+            {{- $name := (index $labels "crossplane.io/claim-name") | default .observed.composite.resource.metadata.name }}
+            {{- $ns := (index $labels "crossplane.io/claim-namespace") | default "default" }}
+            {{- $cpu := $spec.cpu | default 2 }}
+            {{- $memory := $spec.memory | default "2Gi" }}
+            {{- $disk := $spec.diskSize | default "20Gi" }}
+            {{- /* running defaults true; explicit hasKey check because Sprig
+                   `default` treats boolean false as empty (would force true). */}}
+            {{- $running := true }}{{- if hasKey $spec "running" }}{{- $running = $spec.running }}{{- end }}
+            {{- $pass := printf "%s-vmpass" .observed.composite.resource.metadata.uid | sha256sum | trunc 20 }}
+            {{- /* Curated OS catalog: os -> disk image + type. KEEP IN SYNC with the
+                   XRD enum. Linux images are ready-made cloud images (containerdisks)
+                   imported by CDI; windows clones the golden image PVC built once
+                   from an eval ISO (scripts/build-windows-image.sh). */}}
+            {{- $catalog := dict
+                  "ubuntu-24.04"    (dict "image" "quay.io/containerdisks/ubuntu:24.04"    "osType" "linux")
+                  "ubuntu-22.04"    (dict "image" "quay.io/containerdisks/ubuntu:22.04"    "osType" "linux")
+                  "fedora-40"       (dict "image" "quay.io/containerdisks/fedora:40"       "osType" "linux")
+                  "debian-12"       (dict "image" "quay.io/containerdisks/debian:12"       "osType" "linux")
+                  "centos-stream-9" (dict "image" "quay.io/containerdisks/centos-stream:9" "osType" "linux")
+                  "windows"         (dict "image" ""                                       "osType" "windows") }}
+            {{- $profile := (index $catalog $spec.os) | default (dict "image" "quay.io/containerdisks/ubuntu:24.04" "osType" "linux") }}
+            {{- $isWin := eq $profile.osType "windows" }}
+            {{- $port := 22 }}{{- $user := "openinfra" }}{{- $proto := "ssh" }}
+            {{- if $isWin }}{{- $port = 3389 }}{{- $user = "Administrator" }}{{- $proto = "rdp" }}{{- end }}
+            ---
+            # --- The VM. dataVolumeTemplates provisions the persistent root disk via
+            #     CDI (registry import for Linux; clone of the golden PVC for Windows).
+            #     runStrategy follows spec.running so Start/Stop is a spec toggle. ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: virtualmachine
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: kubevirt.io/v1
+                  kind: VirtualMachine
+                  metadata:
+                    name: {{ $name }}
+                    namespace: {{ $ns }}
+                    labels:
+                      app.kubernetes.io/name: {{ $name }}
+                      openinfra.dev/vm: "true"
+                      openinfra.dev/os: {{ $spec.os }}
+                  spec:
+                    runStrategy: {{ if $running }}Always{{ else }}Halted{{ end }}
+                    dataVolumeTemplates:
+                      - metadata:
+                          name: {{ $name }}-root
+                        spec:
+                          storage:
+                            accessModes: [ReadWriteOnce]
+                            resources:
+                              requests:
+                                storage: {{ $disk }}
+                            storageClassName: local-path
+                          source:
+                            {{- if $isWin }}
+                            # Clone the golden Windows image (built once; see docs).
+                            pvc:
+                              namespace: openinfra-images
+                              name: windows-golden
+                            {{- else }}
+                            registry:
+                              url: "docker://{{ $profile.image }}"
+                            {{- end }}
+                    template:
+                      metadata:
+                        labels:
+                          kubevirt.io/domain: {{ $name }}
+                          app.kubernetes.io/name: {{ $name }}
+                      spec:
+                        domain:
+                          cpu:
+                            cores: {{ $cpu }}
+                          resources:
+                            requests:
+                              memory: {{ $memory }}
+                          {{- if $isWin }}
+                          # Windows performance/compat: q35 + UEFI + Hyper-V enlightenments.
+                          machine:
+                            type: q35
+                          features:
+                            acpi: {}
+                            apic: {}
+                            hyperv:
+                              relaxed: {}
+                              vapic: {}
+                              spinlocks:
+                                spinlocks: 8191
+                          clock:
+                            utc: {}
+                            timer:
+                              hpet:
+                                present: false
+                              hyperv: {}
+                          {{- end }}
+                          devices:
+                            disks:
+                              - name: root
+                                disk:
+                                  bus: virtio
+                                bootOrder: 1
+                              - name: cloudinit
+                                disk:
+                                  bus: virtio
+                            interfaces:
+                              - name: default
+                                masquerade: {}
+                            networkInterfaceMultiqueue: true
+                        networks:
+                          - name: default
+                            pod: {}
+                        volumes:
+                          - name: root
+                            dataVolume:
+                              name: {{ $name }}-root
+                          - name: cloudinit
+                            cloudInitNoCloud:
+                              userData: |-
+                                {{- if $isWin }}
+                                #ps1_sysnative
+                                # cloudbase-init runs this on first boot: set the admin
+                                # password (per-VM) and enable RDP for mstsc.
+                                net user {{ $user }} '{{ $pass }}'
+                                Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name fDenyTSConnections -Value 0
+                                Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+                                Set-Service -Name TermService -StartupType Automatic
+                                Start-Service -Name TermService
+                                {{- else }}
+                                #cloud-config
+                                hostname: {{ $name }}
+                                users:
+                                  - name: {{ $user }}
+                                    sudo: ALL=(ALL) NOPASSWD:ALL
+                                    shell: /bin/bash
+                                    lock_passwd: false
+                                    {{- if $spec.sshKey }}
+                                    ssh_authorized_keys:
+                                      - {{ $spec.sshKey }}
+                                    {{- end }}
+                                ssh_pwauth: true
+                                chpasswd:
+                                  expire: false
+                                  list: |
+                                    {{ $user }}:{{ $pass }}
+                                packages:
+                                  - qemu-guest-agent
+                                runcmd:
+                                  - [systemctl, enable, --now, qemu-guest-agent]
+                                {{- end }}
+            ---
+            # --- Service: in-cluster reach to SSH (Linux) / RDP (Windows). ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: service
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Service
+                  metadata: { name: {{ $name }}, namespace: {{ $ns }} }
+                  spec:
+                    selector: { kubevirt.io/domain: {{ $name }} }
+                    ports:
+                      - { name: {{ $proto }}, port: {{ $port }}, targetPort: {{ $port }} }
+            ---
+            # --- Connection Secret: how to log in (cf. the DB/model secret). ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: vm-secret
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Secret
+                  metadata: { name: {{ $name }}-vm, namespace: {{ $ns }} }
+                  stringData:
+                    OS: "{{ $spec.os }}"
+                    PROTOCOL: "{{ $proto }}"
+                    USERNAME: "{{ $user }}"
+                    PASSWORD: "{{ $pass }}"
+                    HOST: "{{ $name }}.{{ $ns }}.svc.cluster.local"
+                    PORT: "{{ $port }}"
+                    {{- if $isWin }}
+                    ACCESS: "mstsc /v:HOST:{{ $port }}  (user {{ $user }})"
+                    {{- else }}
+                    ACCESS: "ssh {{ $user }}@HOST"
+                    {{- end }}
+            {{- if $spec.expose }}
+            ---
+            # --- LAN LoadBalancer (MetalLB): reach the VM from workstations. ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: vm-lan
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: {{ $name }}-lan
+                    namespace: {{ $ns }}
+                    labels: { openinfra.dev/vm-lan: {{ $name }} }
+                  spec:
+                    type: LoadBalancer
+                    selector: { kubevirt.io/domain: {{ $name }} }
+                    ports:
+                      - { name: {{ $proto }}, port: {{ $port }}, targetPort: {{ $port }} }
+            {{- end }}
+    - step: ready
+      functionRef:
+        name: crossplane-contrib-function-auto-ready

--- a/platform/abstraction/vm-xrd.yaml
+++ b/platform/abstraction/vm-xrd.yaml
@@ -1,0 +1,71 @@
+# open-infra's "EC2": a third public API, kind: VirtualMachine. Give it an OS from
+# the curated catalog and get a real VM (KubeVirt) with a persistent disk (CDI),
+# cloud-init/cloudbase-init login, a web VNC console, and SSH (Linux) or RDP
+# (Windows) access — provisioned the same way kind: Application provisions apps.
+# KEEP THIS SCHEMA STABLE — it is part of the product's contract.
+#
+# Synced after Crossplane's CRDs exist (sync-wave 2).
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xvirtualmachines.openinfra.dev
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  group: openinfra.dev
+  names:
+    kind: XVirtualMachine
+    plural: xvirtualmachines
+  claimNames:
+    kind: VirtualMachine   # what users write in infra.yaml
+    plural: virtualmachines
+  defaultCompositionRef:
+    name: vm
+  versions:
+    - name: v1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: [os]
+              properties:
+                # Curated OS catalog (allowlist). Each entry maps to a disk image +
+                # osType in the Composition's $catalog. Linux entries are ready-made
+                # cloud images (containerdisks); "windows" clones a golden image you
+                # build once from an eval ISO (see scripts/build-windows-image.sh).
+                # Adding an OS means adding it here AND to the Composition's $catalog.
+                os:
+                  type: string
+                  description: "Operating system (from the curated catalog)."
+                  enum:
+                    - ubuntu-24.04      # linux · cloud image
+                    - ubuntu-22.04      # linux · cloud image
+                    - fedora-40         # linux · cloud image
+                    - debian-12         # linux · cloud image
+                    - centos-stream-9   # linux · cloud image
+                    - windows           # windows · clones the golden image (eval)
+                cpu:      { type: integer, default: 2, minimum: 1, description: "vCPU cores" }
+                memory:   { type: string, default: "2Gi", description: "Guest RAM" }
+                diskSize: { type: string, default: "20Gi", description: "Root disk size (persistent)" }
+                # SSH public key injected via cloud-init (Linux). If omitted, a
+                # generated password (in the connection secret) is the only login.
+                sshKey:   { type: string, description: "SSH public key for login (Linux)" }
+                # Reach the VM on a LAN IP (MetalLB): SSH (22) for Linux, RDP (3389)
+                # for Windows. Off by default — port-forward / web console otherwise.
+                expose:   { type: boolean, default: false }
+                # Power state. The console's Start/Stop flips this; the Composition
+                # maps it to KubeVirt runStrategy (Always/Halted). Disk is retained
+                # when stopped. Kept in spec (not a subresource) so it stays GitOps-
+                # clean and the provider doesn't fight power changes.
+                running:  { type: boolean, default: true }
+            status:
+              type: object
+              properties:
+                os:      { type: string }
+                ip:      { type: string }
+                ready:   { type: boolean }

--- a/platform/console/manifests/rbac.yaml
+++ b/platform/console/manifests/rbac.yaml
@@ -66,13 +66,28 @@ rules:
     verbs: [get, list, watch]
 
   # ── openinfra.dev: full CRUD on the product CRDs (the console is the primary
-  #    interface for creating/updating/deleting Applications, Functions, Models) ─
+  #    interface for creating/updating/deleting Applications, Functions, Models,
+  #    VirtualMachines). VM Start/Stop is a patch of the claim's spec.running. ─
   - apiGroups: [openinfra.dev]
     resources:
       - applications
       - functions
       - models
+      - virtualmachines
     verbs: [get, list, watch, create, update, patch, delete]
+
+  # ── KubeVirt + CDI: read VM/guest/disk status for the Virtual Machines view
+  #    (IP, phase, import progress). The VM objects themselves are created via the
+  #    openinfra.dev claim above; these are read-only live status. ──────────────
+  - apiGroups: [kubevirt.io]
+    resources:
+      - virtualmachines
+      - virtualmachineinstances
+    verbs: [get, list, watch]
+  - apiGroups: [cdi.kubevirt.io]
+    resources:
+      - datavolumes
+    verbs: [get, list, watch]
 
   # ── CloudNativePG: read managed Postgres clusters (the Databases view) ──────
   - apiGroups: [postgresql.cnpg.io]

--- a/scripts/build-windows-image.sh
+++ b/scripts/build-windows-image.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────
+# Build the open-infra Windows golden image (one-time, operator-run).
+#
+# Produces a generalized Windows disk as the PVC <name> in <namespace>, which the
+# kind: VirtualMachine Composition clones for every `os: windows` VM.
+#
+#   scripts/build-windows-image.sh --windows-iso <url|path> [opts]
+#
+# Requires: kubectl, virtctl, and genisoimage (or mkisofs) locally; KubeVirt+CDI
+# installed; a Windows EVALUATION ISO (Server 2022 by default). Eval editions are
+# free for non-production testing only — see docs/virtual-machines.md (licensing).
+# ─────────────────────────────────────────────────────────────
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG() { printf '\033[1;36m[win-image]\033[0m %s\n' "$*"; }
+DIE() { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+WIN_ISO=""
+VIRTIO_ISO="https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/stable-virtio/virtio-win.iso"
+NAME="windows-golden"
+NS="openinfra-images"
+DISK_SIZE="64Gi"
+RAM="6Gi"
+CPU="4"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --windows-iso) WIN_ISO="$2"; shift 2 ;;
+    --virtio-iso)  VIRTIO_ISO="$2"; shift 2 ;;
+    --name)        NAME="$2"; shift 2 ;;
+    --namespace)   NS="$2"; shift 2 ;;
+    --disk-size)   DISK_SIZE="$2"; shift 2 ;;
+    -h|--help)     grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -16; exit 0 ;;
+    *) DIE "unknown arg: $1" ;;
+  esac
+done
+[ -n "$WIN_ISO" ] || DIE "--windows-iso <url|path> is required (a Windows eval ISO)"
+command -v kubectl  >/dev/null || DIE "kubectl is required"
+command -v virtctl  >/dev/null || DIE "virtctl is required (CDI image upload)"
+ISO_TOOL="$(command -v genisoimage || command -v mkisofs || true)"
+[ -n "$ISO_TOOL" ] || DIE "genisoimage or mkisofs is required"
+
+LOG "namespace=$NS golden=$NAME disk=$DISK_SIZE"
+kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
+# 1. Build the aux ISO (autounattend.xml + setup.ps1 at the root). Windows Setup
+#    auto-detects autounattend.xml on attached removable media.
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cp "$HERE/windows/autounattend.xml" "$HERE/windows/setup.ps1" "$TMP/"
+"$ISO_TOOL" -quiet -J -r -V OIUNATTEND -o "$TMP/aux.iso" "$TMP" >/dev/null 2>&1 || \
+  "$ISO_TOOL" -J -r -V OIUNATTEND -o "$TMP/aux.iso" "$TMP"
+LOG "built aux ISO ($(du -h "$TMP/aux.iso" | cut -f1))"
+
+# 2. Import the Windows + virtio ISOs into PVCs via CDI.
+import_dv() { # name  source(url|path)
+  local n="$1" src="$2"
+  if [ -f "$src" ]; then
+    LOG "uploading $n from local file $src"
+    virtctl image-upload dv "$n" --namespace "$NS" --size=10Gi \
+      --image-path="$src" --insecure --force
+  else
+    LOG "importing $n from $src"
+    cat <<EOF | kubectl apply -f -
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata: { name: $n, namespace: $NS }
+spec:
+  source: { http: { url: "$src" } }
+  storage:
+    accessModes: [ReadWriteOnce]
+    resources: { requests: { storage: 10Gi } }
+    storageClassName: local-path
+EOF
+  fi
+}
+import_dv "${NAME}-winiso" "$WIN_ISO"
+import_dv "${NAME}-virtio" "$VIRTIO_ISO"
+
+LOG "uploading aux ISO"
+virtctl image-upload dv "${NAME}-aux" --namespace "$NS" --size=1Gi \
+  --image-path="$TMP/aux.iso" --insecure --force
+
+# 3. The golden disk — STANDALONE DataVolume (not a VM dataVolumeTemplate) so
+#    deleting the installer VM later does NOT delete the image.
+cat <<EOF | kubectl apply -f -
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata: { name: $NAME, namespace: $NS }
+spec:
+  source: { blank: {} }
+  storage:
+    accessModes: [ReadWriteOnce]
+    resources: { requests: { storage: $DISK_SIZE } }
+    storageClassName: local-path
+EOF
+
+LOG "waiting for ISO imports to finish…"
+for dv in "${NAME}-winiso" "${NAME}-virtio"; do
+  kubectl wait --for=condition=Ready "datavolume/$dv" -n "$NS" --timeout=1800s || true
+done
+
+# 4. Installer VM: boot the Windows ISO, install onto the golden disk (virtio),
+#    with the virtio + aux ISOs attached. setup.ps1 finishes + sysprep shuts down.
+cat <<EOF | kubectl apply -f -
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata: { name: ${NAME}-installer, namespace: $NS }
+spec:
+  runStrategy: Always
+  template:
+    spec:
+      domain:
+        cpu: { cores: $CPU }
+        resources: { requests: { memory: $RAM } }
+        machine: { type: q35 }
+        features: { acpi: {}, apic: {}, smm: {} }
+        firmware: { bootloader: { efi: { secureBoot: false } } }
+        devices:
+          disks:
+            - { name: target, disk: { bus: virtio }, bootOrder: 2 }
+            - { name: winiso, cdrom: { bus: sata }, bootOrder: 1 }
+            - { name: virtio, cdrom: { bus: sata } }
+            - { name: aux,    cdrom: { bus: sata } }
+          interfaces: [ { name: default, masquerade: {} } ]
+        networkInterfaceMultiqueue: true
+      networks: [ { name: default, pod: {} } ]
+      volumes:
+        - { name: target, persistentVolumeClaim: { claimName: $NAME } }
+        - { name: winiso, persistentVolumeClaim: { claimName: ${NAME}-winiso } }
+        - { name: virtio, persistentVolumeClaim: { claimName: ${NAME}-virtio } }
+        - { name: aux,    persistentVolumeClaim: { claimName: ${NAME}-aux } }
+EOF
+
+cat <<NEXT
+
+Installer VM '${NAME}-installer' is running in '$NS'.
+Watch it:   virtctl vnc ${NAME}-installer -n $NS     (or any VNC client)
+            kubectl get vmi ${NAME}-installer -n $NS -w
+
+It installs Windows unattended, runs setup.ps1 (virtio tools + cloudbase-init +
+RDP), then sysprep-generalizes and SHUTS DOWN. When the VMI is gone / VM is
+Stopped, the build is done. Then clean up (keeps the golden '$NAME'):
+
+  kubectl delete vm ${NAME}-installer -n $NS
+  kubectl delete dv ${NAME}-winiso ${NAME}-virtio ${NAME}-aux -n $NS
+
+After that, 'spec.os: windows' VMs clone '$NS/$NAME'.
+NEXT
+LOG "submitted. (full Windows install can take 20–40 min)"

--- a/scripts/windows/autounattend.xml
+++ b/scripts/windows/autounattend.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Unattended install for the open-infra Windows golden image.
+  Targets Windows Server 2022 Standard (Desktop Experience), evaluation edition,
+  installed directly onto a KubeVirt virtio disk (viostor driver injected in
+  WinPE). After install, SetupComplete.cmd installs cloudbase-init (which sets the
+  per-VM Administrator password + enables RDP from the VM's cloud-init), the
+  virtio guest tools and qemu-guest-agent, then sysprep generalizes the image.
+
+  Adjust for other Windows versions: the image /Value (edition), the driver paths
+  (\2k22\), and the disk layout if not UEFI. The virtio ISO mounts as drive E:.
+-->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <SetupUILanguage><UILanguage>en-US</UILanguage></SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+    <component name="Microsoft-Windows-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <!-- Inject the virtio block driver so Setup can see the virtio disk. -->
+      <DriverPaths>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="1"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Path>E:\viostor\2k22\amd64</Path>
+        </PathAndCredentials>
+        <PathAndCredentials wcm:action="add" wcm:keyValue="2"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Path>E:\NetKVM\2k22\amd64</Path>
+        </PathAndCredentials>
+      </DriverPaths>
+      <DiskConfiguration>
+        <Disk wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add"><Order>1</Order><Type>EFI</Type><Size>200</Size></CreatePartition>
+            <CreatePartition wcm:action="add"><Order>2</Order><Type>MSR</Type><Size>16</Size></CreatePartition>
+            <CreatePartition wcm:action="add"><Order>3</Order><Type>Primary</Type><Extend>true</Extend></CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add"><Order>1</Order><PartitionID>1</PartitionID><Format>FAT32</Format><Label>System</Label></ModifyPartition>
+            <ModifyPartition wcm:action="add"><Order>2</Order><PartitionID>2</PartitionID></ModifyPartition>
+            <ModifyPartition wcm:action="add"><Order>3</Order><PartitionID>3</PartitionID><Format>NTFS</Format><Label>Windows</Label><Letter>C</Letter></ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+      <ImageInstall>
+        <OSImage>
+          <InstallTo><DiskID>0</DiskID><PartitionID>3</PartitionID></InstallTo>
+          <InstallFrom>
+            <MetaData wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+              <Key>/IMAGE/NAME</Key>
+              <Value>Windows Server 2022 Standard Evaluation (Desktop Experience)</Value>
+            </MetaData>
+          </InstallFrom>
+        </OSImage>
+      </ImageInstall>
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>openinfra</FullName>
+        <Organization>open-infra</Organization>
+      </UserData>
+    </component>
+  </settings>
+
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-Shell-Setup"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
+      <UserAccounts>
+        <!-- Temporary build password; cloudbase-init resets it per-VM on first
+             boot from the cloud-init userdata the Composition injects. -->
+        <AdministratorPassword><Value>Cl0udbase!Build</Value><PlainText>true</PlainText></AdministratorPassword>
+      </UserAccounts>
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <NetworkLocation>Work</NetworkLocation>
+        <ProtectYourPC>3</ProtectYourPC>
+      </OOBE>
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <LogonCount>1</LogonCount>
+        <Username>Administrator</Username>
+        <Password><Value>Cl0udbase!Build</Value><PlainText>true</PlainText></Password>
+      </AutoLogon>
+      <TimeZone>UTC</TimeZone>
+      <!-- After first auto-logon, run the post-install script from whichever
+           removable drive carries it (the aux ISO built by build-windows-image.sh). -->
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>1</Order>
+          <Description>open-infra post-install</Description>
+          <CommandLine>powershell -ExecutionPolicy Bypass -Command "$p = Get-ChildItem -Path @('A:\','D:\','E:\','F:\','G:\') -Filter setup.ps1 -ErrorAction SilentlyContinue | Select-Object -First 1; if ($p) { &amp; $p.FullName }"</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>

--- a/scripts/windows/setup.ps1
+++ b/scripts/windows/setup.ps1
@@ -1,0 +1,66 @@
+# open-infra Windows golden-image post-install.
+# Runs once (FirstLogonCommands) after an unattended Server 2022 install:
+#   - installs the virtio guest tools + qemu-guest-agent (from the virtio ISO),
+#   - installs + enables cloudbase-init (sets the per-VM Administrator password
+#     and other cloud-init from the VM's NoCloud userdata on every boot),
+#   - enables RDP + the firewall rule,
+#   - generalizes the image with sysprep and shuts down -> the disk is the golden
+#     image the Composition clones for each `os: windows` VM.
+$ErrorActionPreference = 'Stop'
+Write-Host 'open-infra: post-install starting'
+
+# --- Locate the virtio ISO (it carries the guest tools + qemu-ga installers) ---
+$virtio = (Get-Volume | Where-Object { $_.DriveType -eq 'CD-ROM' } |
+  ForEach-Object { $_.DriveLetter } |
+  Where-Object { $_ -and (Test-Path ("{0}:\virtio-win-guest-tools.exe" -f $_)) } |
+  Select-Object -First 1)
+
+if ($virtio) {
+  Write-Host "open-infra: installing virtio guest tools from ${virtio}:"
+  Start-Process -Wait -FilePath ("{0}:\virtio-win-guest-tools.exe" -f $virtio) -ArgumentList '/install','/quiet','/norestart'
+  $qemuGa = "{0}:\guest-agent\qemu-ga-x86_64.msi" -f $virtio
+  if (Test-Path $qemuGa) {
+    Start-Process -Wait -FilePath msiexec.exe -ArgumentList '/i', $qemuGa, '/quiet', '/norestart'
+  }
+} else {
+  Write-Warning 'open-infra: virtio ISO not found — guest tools/qemu-ga skipped'
+}
+
+# --- Enable Remote Desktop (cloudbase-init re-asserts this per VM too) ---
+Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name fDenyTSConnections -Value 0
+Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+Set-Service -Name TermService -StartupType Automatic
+
+# --- Install cloudbase-init (the Windows cloud-init) ---
+$cbUrl = 'https://github.com/cloudbase/cloudbase-init/releases/latest/download/CloudbaseInitSetup_x64.msi'
+$cbMsi = "$env:TEMP\cloudbase-init.msi"
+Write-Host 'open-infra: downloading cloudbase-init'
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri $cbUrl -OutFile $cbMsi
+# Silent install; do NOT run sysprep via the MSI (we control sysprep below).
+Start-Process -Wait -FilePath msiexec.exe -ArgumentList '/i', $cbMsi, '/qn', 'RUN_SERVICE_AS_LOCAL_SYSTEM=1', 'LoggingLevel=verbose'
+
+# Point cloudbase-init at the NoCloud (ConfigDrive) datasource KubeVirt presents,
+# and allow the password/RDP plugins. Minimal conf; tune as needed.
+$cbDir = 'C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf'
+if (Test-Path $cbDir) {
+@'
+[DEFAULT]
+username=Administrator
+groups=Administrators
+inject_user_password=true
+config_drive_raw_hhd=true
+config_drive_cdrom=true
+config_drive_vfat=true
+bsdtar_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\bsdtar.exe
+mtools_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\
+metadata_services=cloudbaseinit.metadata.services.nocloudservice.NoCloudConfigDriveService
+plugins=cloudbaseinit.plugins.common.mtu.MTUPlugin,cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin,cloudbaseinit.plugins.common.userdata.UserDataPlugin,cloudbaseinit.plugins.common.setuserpassword.SetUserPasswordPlugin
+allow_reboot=false
+stop_service_on_exit=false
+'@ | Set-Content -Path (Join-Path $cbDir 'cloudbase-init.conf') -Encoding ASCII
+}
+
+# --- Generalize + shut down. The resulting disk is the golden image. ---
+Write-Host 'open-infra: sysprep generalize + shutdown'
+& "$env:WINDIR\System32\Sysprep\Sysprep.exe" /generalize /oobe /shutdown /quiet

--- a/ui/src/components/layout/nav-items.ts
+++ b/ui/src/components/layout/nav-items.ts
@@ -6,6 +6,7 @@ import {
   HardDrive,
   LayoutDashboard,
   LineChart,
+  Monitor,
   Network,
   Send,
   Server,
@@ -29,6 +30,7 @@ export const NAV_ITEMS: NavItem[] = [
 
   { label: "Applications", to: "/applications", icon: Boxes, matchPrefix: true, section: "Compute" },
   { label: "Functions", to: "/functions", icon: Zap, matchPrefix: true, section: "Compute" },
+  { label: "Virtual Machines", to: "/vms", icon: Monitor, matchPrefix: true, section: "Compute" },
 
   { label: "Models", to: "/models", icon: BrainCircuit, matchPrefix: true, section: "AI" },
 

--- a/ui/src/features/vms/new-vm-dialog.tsx
+++ b/ui/src/features/vms/new-vm-dialog.tsx
@@ -1,0 +1,270 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Monitor, Rocket } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/common/states";
+import { ApiError, k8sCreate } from "@/lib/api";
+import { openinfraPaths } from "@/lib/k8s-paths";
+import { watchQueryKey } from "@/hooks/use-k8s-watch";
+import {
+  OPENINFRA_GROUP,
+  OPENINFRA_VERSION,
+  type K8sObject,
+} from "@/types/k8s";
+import { OS_CATALOG, osFamily } from "./vm-shared";
+
+const RFC1123 = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+/**
+ * Provision a VM without writing YAML: name, OS (from the catalog), size, an SSH
+ * key (Linux) and optional LAN exposure. Creates a kind: VirtualMachine claim.
+ */
+export function NewVmDialog({
+  open,
+  onOpenChange,
+  namespaces,
+  defaultNamespace,
+  listPath,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  namespaces: string[];
+  defaultNamespace?: string;
+  listPath: string;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [namespace, setNamespace] = useState(defaultNamespace ?? "default");
+  const [os, setOs] = useState("ubuntu-24.04");
+  const [cpu, setCpu] = useState("2");
+  const [memory, setMemory] = useState("2Gi");
+  const [diskSize, setDiskSize] = useState("20Gi");
+  const [sshKey, setSshKey] = useState("");
+  const [expose, setExpose] = useState(false);
+  const [touched, setTouched] = useState(false);
+
+  const isWindows = osFamily(os) === "windows";
+
+  function reset() {
+    setName("");
+    setOs("ubuntu-24.04");
+    setCpu("2");
+    setMemory("2Gi");
+    setDiskSize("20Gi");
+    setSshKey("");
+    setExpose(false);
+    setTouched(false);
+    createMutation.reset();
+  }
+
+  const createMutation = useMutation({
+    mutationFn: (manifest: K8sObject) =>
+      k8sCreate<K8sObject>(openinfraPaths.virtualmachines(namespace), manifest),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: watchQueryKey(listPath) });
+      reset();
+      onOpenChange(false);
+    },
+  });
+
+  const nameError =
+    touched && !RFC1123.test(name)
+      ? "Lowercase letters, numbers and hyphens; must start/end alphanumeric."
+      : null;
+
+  const submit = () => {
+    if (!RFC1123.test(name)) {
+      setTouched(true);
+      return;
+    }
+    createMutation.mutate({
+      apiVersion: `${OPENINFRA_GROUP}/${OPENINFRA_VERSION}`,
+      kind: "VirtualMachine",
+      metadata: { name, namespace },
+      spec: {
+        os,
+        cpu: Number(cpu) || 2,
+        memory: memory || "2Gi",
+        diskSize: diskSize || "20Gi",
+        ...(sshKey.trim() && !isWindows ? { sshKey: sshKey.trim() } : {}),
+        expose,
+      },
+    } as K8sObject);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (createMutation.isPending) return;
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Monitor className="size-5 text-primary" />
+            New Virtual Machine
+          </DialogTitle>
+          <DialogDescription>
+            A real VM with a persistent disk — no YAML needed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="space-y-1.5">
+            <Label htmlFor="vm-name">Name</Label>
+            <Input
+              id="vm-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={() => setTouched(true)}
+              placeholder="dev-box"
+              autoFocus
+            />
+            {nameError ? (
+              <p className="text-xs text-destructive">{nameError}</p>
+            ) : null}
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="vm-ns">Namespace</Label>
+            <Select value={namespace} onValueChange={setNamespace}>
+              <SelectTrigger id="vm-ns">
+                <SelectValue placeholder="Namespace" />
+              </SelectTrigger>
+              <SelectContent>
+                {(namespaces.length ? namespaces : [namespace]).map((ns) => (
+                  <SelectItem key={ns} value={ns}>
+                    {ns}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5 sm:col-span-2">
+            <Label htmlFor="vm-os">Operating system</Label>
+            <Select value={os} onValueChange={setOs}>
+              <SelectTrigger id="vm-os">
+                <SelectValue placeholder="OS" />
+              </SelectTrigger>
+              <SelectContent>
+                {OS_CATALOG.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="vm-cpu">vCPU</Label>
+            <Input
+              id="vm-cpu"
+              type="number"
+              min={1}
+              value={cpu}
+              onChange={(e) => setCpu(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="vm-mem">Memory</Label>
+            <Input
+              id="vm-mem"
+              value={memory}
+              onChange={(e) => setMemory(e.target.value)}
+              placeholder="2Gi"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="vm-disk">Disk size</Label>
+            <Input
+              id="vm-disk"
+              value={diskSize}
+              onChange={(e) => setDiskSize(e.target.value)}
+              placeholder="20Gi"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>LAN access</Label>
+            <label className="flex h-9 items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={expose}
+                onChange={(e) => setExpose(e.target.checked)}
+                className="size-4 accent-primary"
+              />
+              <span className="text-muted-foreground">
+                {isWindows ? "RDP (3389)" : "SSH (22)"} on a LAN IP
+              </span>
+            </label>
+          </div>
+          {isWindows ? (
+            <div className="sm:col-span-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-xs text-muted-foreground">
+              Windows clones a golden image you build once from an eval ISO (see
+              docs). Login is <span className="font-medium">Administrator</span> +
+              a generated password (revealable on the VM page); connect with{" "}
+              <code>mstsc</code> over RDP.
+            </div>
+          ) : (
+            <div className="space-y-1.5 sm:col-span-2">
+              <Label htmlFor="vm-ssh">SSH public key</Label>
+              <Input
+                id="vm-ssh"
+                value={sshKey}
+                onChange={(e) => setSshKey(e.target.value)}
+                placeholder="ssh-ed25519 AAAA… (optional — else use the generated password)"
+              />
+            </div>
+          )}
+        </div>
+
+        {createMutation.error ? (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+            {createMutation.error instanceof ApiError
+              ? createMutation.error.message
+              : "Failed to create the VM."}
+          </div>
+        ) : null}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={createMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={createMutation.isPending || !RFC1123.test(name)}
+          >
+            {createMutation.isPending ? (
+              <Spinner className="text-current" />
+            ) : (
+              <Rocket className="size-4" />
+            )}
+            Create VM
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/features/vms/vm-detail-page.tsx
+++ b/ui/src/features/vms/vm-detail-page.tsx
@@ -1,0 +1,273 @@
+import { useState } from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { Eye, EyeOff, Monitor, Play, Power } from "lucide-react";
+import { DetailShell } from "@/components/common/detail-shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { DetailRow } from "@/components/common/detail-row";
+import { CopyButton } from "@/components/common/copy-button";
+import { YamlViewer } from "@/components/common/yaml-viewer";
+import { GrafanaEmbed } from "@/components/common/grafana-embed";
+import { ResourceNameRow } from "@/components/common/resource-name-row";
+import { DangerZone } from "@/components/common/danger-zone";
+import { LoadingState, ErrorState } from "@/components/common/states";
+import { k8sDelete, k8sGet, k8sReplace } from "@/lib/api";
+import { kubevirtPaths, openinfraPaths, resourcePaths } from "@/lib/k8s-paths";
+import type { K8sObject, VirtualMachine, Vmi } from "@/types/k8s";
+import { osFamily, osLabel, vmIp, vmStatus } from "./vm-shared";
+
+function decode(v?: string): string {
+  if (!v) return "";
+  try {
+    return atob(v);
+  } catch {
+    return "";
+  }
+}
+
+type SvcStatus = K8sObject<
+  unknown,
+  { loadBalancer?: { ingress?: { ip?: string }[] } }
+>;
+
+export function VmDetailPage() {
+  const { namespace, name } = useParams({ strict: false }) as {
+    namespace: string;
+    name: string;
+  };
+  const navigate = useNavigate();
+  const [showPass, setShowPass] = useState(false);
+
+  const vmPath = openinfraPaths.virtualmachine(namespace, name);
+
+  const { data: vm, isLoading, isError, error, refetch } = useQuery({
+    queryKey: ["vm", namespace, name],
+    queryFn: () => k8sGet<VirtualMachine>(vmPath),
+    refetchInterval: 5000,
+  });
+
+  const { data: vmi } = useQuery({
+    queryKey: ["vmi", namespace, name],
+    queryFn: () => k8sGet<Vmi>(kubevirtPaths.vmi(namespace, name)),
+    refetchInterval: 5000,
+    retry: false,
+  });
+
+  const { data: secret } = useQuery({
+    queryKey: ["vm-secret", namespace, name],
+    enabled: Boolean(vm),
+    queryFn: () =>
+      k8sGet<K8sObject & { data?: Record<string, string> }>(
+        `/api/v1/namespaces/${namespace}/secrets/${name}-vm`,
+      ),
+    retry: false,
+  });
+
+  const { data: lanSvc } = useQuery({
+    queryKey: ["vm-lan", namespace, name],
+    enabled: Boolean(vm?.spec?.expose),
+    queryFn: () =>
+      k8sGet<SvcStatus>(resourcePaths.service(namespace, `${name}-lan`)),
+    retry: false,
+    refetchInterval: 5000,
+  });
+
+  const power = useMutation({
+    mutationFn: async (running: boolean) => {
+      const cur = await k8sGet<VirtualMachine>(vmPath);
+      return k8sReplace<VirtualMachine>(vmPath, {
+        ...cur,
+        spec: { ...(cur.spec ?? {}), running },
+      } as VirtualMachine);
+    },
+    onSuccess: () => void refetch(),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => k8sDelete(vmPath),
+    onSuccess: () => navigate({ to: "/vms" }),
+  });
+
+  if (isLoading) return <LoadingState label="Loading VM…" />;
+  if (isError || !vm) return <ErrorState error={error} onRetry={refetch} />;
+
+  const spec = vm.spec;
+  const family = osFamily(spec?.os);
+  const isWin = family === "windows";
+  const running = spec?.running !== false;
+  const status = vmStatus(vm, vmi);
+  const ip = vmIp(vmi);
+  const lanIp = lanSvc?.status?.loadBalancer?.ingress?.[0]?.ip;
+
+  const username = decode(secret?.data?.USERNAME) || (isWin ? "Administrator" : "openinfra");
+  const password = decode(secret?.data?.PASSWORD);
+  const port = decode(secret?.data?.PORT) || (isWin ? "3389" : "22");
+
+  const reachHost = lanIp ?? "<port-forward>";
+  const connectCmd = isWin
+    ? `mstsc /v:${reachHost}:${port}`
+    : `ssh ${username}@${reachHost}`;
+  const portForward = `kubectl port-forward -n ${namespace} svc/${name} ${port}:${port}`;
+
+  return (
+    <DetailShell
+      backTo="/vms"
+      backLabel="Virtual Machines"
+      icon={<Monitor className="size-5" />}
+      title={name}
+      subtitle={`${osLabel(spec?.os)} · ${namespace}`}
+      status={status}
+      actions={
+        running ? (
+          <Button
+            variant="outline"
+            onClick={() => power.mutate(false)}
+            disabled={power.isPending}
+          >
+            <Power className="size-4" /> Stop
+          </Button>
+        ) : (
+          <Button onClick={() => power.mutate(true)} disabled={power.isPending}>
+            <Play className="size-4" /> Start
+          </Button>
+        )
+      }
+    >
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="access">Access</TabsTrigger>
+          <TabsTrigger value="monitoring">Monitoring</TabsTrigger>
+          <TabsTrigger value="yaml">YAML</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="pt-4">
+          <Card>
+            <CardContent className="divide-y divide-border p-0">
+              <ResourceNameRow kind="vm" name={name} namespace={namespace} />
+              <DetailRow label="Operating system">
+                <Badge variant="secondary">{osLabel(spec?.os)}</Badge>
+              </DetailRow>
+              <DetailRow label="Size">
+                <span className="font-mono text-xs">
+                  {spec?.cpu ?? 2} vCPU · {spec?.memory ?? "2Gi"} RAM ·{" "}
+                  {spec?.diskSize ?? "20Gi"} disk
+                </span>
+              </DetailRow>
+              <DetailRow label="Power">{running ? "On" : "Off (disk retained)"}</DetailRow>
+              <DetailRow label="IP address">
+                {ip ? <code className="text-xs">{ip}</code> : "—"}
+              </DetailRow>
+              <DetailRow label="Node">{vmi?.status?.nodeName ?? "—"}</DetailRow>
+              <DetailRow label="Namespace">{namespace}</DetailRow>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="access" className="pt-4">
+          <Card>
+            <CardContent className="divide-y divide-border p-0">
+              <DetailRow label={isWin ? "Connect (RDP)" : "Connect (SSH)"}>
+                <span className="flex items-center gap-1">
+                  <code className="text-xs">{connectCmd}</code>
+                  <CopyButton value={connectCmd} />
+                </span>
+              </DetailRow>
+              <DetailRow label="Username">
+                <span className="flex items-center gap-1">
+                  <code className="text-xs">{username}</code>
+                  <CopyButton value={username} />
+                </span>
+              </DetailRow>
+              <DetailRow label="Password">
+                <span className="flex items-center gap-1">
+                  <code className="text-xs">
+                    {password ? (showPass ? password : "•".repeat(16)) : "—"}
+                  </code>
+                  {password ? (
+                    <>
+                      <button
+                        onClick={() => setShowPass((s) => !s)}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label={showPass ? "Hide password" : "Show password"}
+                      >
+                        {showPass ? (
+                          <EyeOff className="size-4" />
+                        ) : (
+                          <Eye className="size-4" />
+                        )}
+                      </button>
+                      <CopyButton value={password} />
+                    </>
+                  ) : null}
+                </span>
+              </DetailRow>
+              {!isWin ? (
+                <DetailRow label="Key login">
+                  {spec?.sshKey
+                    ? "Your SSH key was installed via cloud-init."
+                    : "No key set — use the password above."}
+                </DetailRow>
+              ) : null}
+              <DetailRow label={spec?.expose ? "LAN endpoint" : "LAN endpoint"}>
+                {spec?.expose ? (
+                  lanIp ? (
+                    <code className="text-xs">
+                      {lanIp}:{port}
+                    </code>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      pending MetalLB IP…
+                    </span>
+                  )
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    not exposed — use port-forward below
+                  </span>
+                )}
+              </DetailRow>
+              <DetailRow label="Port-forward">
+                <span className="flex items-center gap-1">
+                  <code className="text-xs">{portForward}</code>
+                  <CopyButton value={portForward} />
+                </span>
+              </DetailRow>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="monitoring" className="pt-4">
+          {/* Scoped to this VM's virt-launcher pod (the VM's host process). */}
+          <GrafanaEmbed
+            uid="openinfra-app-overview"
+            vars={{
+              "var-namespace": namespace,
+              "var-pod": `virt-launcher-${name}-.*`,
+            }}
+          />
+        </TabsContent>
+
+        <TabsContent value="yaml" className="pt-4">
+          <YamlViewer value={vm} />
+        </TabsContent>
+      </Tabs>
+
+      <DangerZone
+        resourceLabel="Virtual Machine"
+        resourceName={name}
+        deleting={deleteMutation.isPending}
+        onConfirm={() => deleteMutation.mutate()}
+        confirmDescription={
+          <>
+            Permanently delete the VM{" "}
+            <span className="font-medium text-foreground">{name}</span> and its
+            disk. This cannot be undone.
+          </>
+        }
+      />
+    </DetailShell>
+  );
+}

--- a/ui/src/features/vms/vm-shared.ts
+++ b/ui/src/features/vms/vm-shared.ts
@@ -1,0 +1,52 @@
+// Shared bits for the Virtual Machines views: the OS catalog (in sync with the
+// XRD enum + the Composition $catalog) and status/IP derivation from the claim +
+// its KubeVirt VirtualMachineInstance.
+import type { StatusTone } from "@/lib/format";
+import type { VirtualMachine, Vmi } from "@/types/k8s";
+
+export interface OsEntry {
+  value: string;
+  label: string;
+  family: "linux" | "windows";
+}
+
+// KEEP IN SYNC with platform/abstraction/vm-xrd.yaml (os enum).
+export const OS_CATALOG: OsEntry[] = [
+  { value: "ubuntu-24.04", label: "Ubuntu 24.04 LTS", family: "linux" },
+  { value: "ubuntu-22.04", label: "Ubuntu 22.04 LTS", family: "linux" },
+  { value: "fedora-40", label: "Fedora 40", family: "linux" },
+  { value: "debian-12", label: "Debian 12", family: "linux" },
+  { value: "centos-stream-9", label: "CentOS Stream 9", family: "linux" },
+  { value: "windows", label: "Windows (eval golden image)", family: "windows" },
+];
+
+export function osLabel(v?: string): string {
+  return OS_CATALOG.find((o) => o.value === v)?.label ?? v ?? "—";
+}
+
+export function osFamily(v?: string): "linux" | "windows" {
+  return OS_CATALOG.find((o) => o.value === v)?.family ?? "linux";
+}
+
+export function vmKey(ns?: string, name?: string): string {
+  return `${ns ?? ""}/${name ?? ""}`;
+}
+
+/** Power/lifecycle status from the claim's spec.running + the live VMI phase. */
+export function vmStatus(
+  vm: VirtualMachine,
+  vmi?: Vmi,
+): { label: string; tone: StatusTone } {
+  if (vm.metadata.deletionTimestamp)
+    return { label: "Terminating", tone: "warning" };
+  const running = vm.spec?.running !== false; // default true
+  if (!running) return { label: "Stopped", tone: "muted" };
+  const phase = vmi?.status?.phase;
+  if (phase === "Running") return { label: "Running", tone: "success" };
+  if (phase) return { label: phase, tone: "warning" }; // Pending/Scheduling/…
+  return { label: "Provisioning", tone: "warning" }; // no VMI yet (disk import)
+}
+
+export function vmIp(vmi?: Vmi): string | undefined {
+  return vmi?.status?.interfaces?.find((i) => i.ipAddress)?.ipAddress;
+}

--- a/ui/src/features/vms/vms-page.tsx
+++ b/ui/src/features/vms/vms-page.tsx
@@ -1,0 +1,170 @@
+import { useMemo, useState } from "react";
+import { type ColumnDef } from "@tanstack/react-table";
+import { useNavigate } from "@tanstack/react-router";
+import { Monitor, Plus } from "lucide-react";
+import { StatusBadge } from "@/components/common/status-badge";
+import { ResourceTablePage } from "@/components/common/resource-table-page";
+import { Button } from "@/components/ui/button";
+import { useK8sWatch } from "@/hooks/use-k8s-watch";
+import { useNamespace } from "@/lib/namespace-context";
+import { corePaths, kubevirtPaths, openinfraPaths } from "@/lib/k8s-paths";
+import { age } from "@/lib/format";
+import { type K8sObject, type VirtualMachine, type Vmi } from "@/types/k8s";
+import { NewVmDialog } from "./new-vm-dialog";
+import { osLabel, vmIp, vmKey, vmStatus } from "./vm-shared";
+
+export function VmsPage() {
+  const navigate = useNavigate();
+  const { scoped } = useNamespace();
+  const [newOpen, setNewOpen] = useState(false);
+
+  // Live guest status (IP, phase) keyed by namespace/name.
+  const vmiWatch = useK8sWatch<Vmi>(kubevirtPaths.vmis(scoped));
+  const vmiByKey = useMemo(() => {
+    const m = new Map<string, Vmi>();
+    for (const v of vmiWatch.items)
+      m.set(vmKey(v.metadata.namespace, v.metadata.name), v);
+    return m;
+  }, [vmiWatch.items]);
+
+  const nsWatch = useK8sWatch<K8sObject>(corePaths.namespaces());
+  const namespaces = nsWatch.items
+    .map((n) => n.metadata.name)
+    .filter((n): n is string => Boolean(n))
+    .sort((a, b) => a.localeCompare(b));
+
+  const columns = useMemo<ColumnDef<VirtualMachine, unknown>[]>(
+    () => [
+      {
+        id: "name",
+        header: "Name",
+        accessorFn: (vm) => vm.metadata.name,
+        cell: ({ row }) => (
+          <span className="font-medium">{row.original.metadata.name}</span>
+        ),
+        size: 180,
+      },
+      {
+        id: "namespace",
+        header: "Namespace",
+        accessorFn: (vm) => vm.metadata.namespace,
+        cell: ({ row }) => (
+          <span className="text-muted-foreground">
+            {row.original.metadata.namespace}
+          </span>
+        ),
+        size: 120,
+      },
+      {
+        id: "os",
+        header: "OS",
+        accessorFn: (vm) => vm.spec?.os ?? "",
+        cell: ({ row }) => (
+          <span className="text-sm">{osLabel(row.original.spec?.os)}</span>
+        ),
+        size: 180,
+      },
+      {
+        id: "size",
+        header: "Size",
+        accessorFn: (vm) => vm.spec?.cpu ?? 0,
+        cell: ({ row }) => (
+          <span className="font-mono text-xs text-muted-foreground">
+            {row.original.spec?.cpu ?? 2} vCPU · {row.original.spec?.memory ?? "2Gi"}
+          </span>
+        ),
+        size: 150,
+      },
+      {
+        id: "ip",
+        header: "IP",
+        accessorFn: (vm) =>
+          vmIp(vmiByKey.get(vmKey(vm.metadata.namespace, vm.metadata.name))) ??
+          "",
+        cell: ({ row }) => {
+          const ip = vmIp(
+            vmiByKey.get(
+              vmKey(row.original.metadata.namespace, row.original.metadata.name),
+            ),
+          );
+          return ip ? (
+            <code className="text-xs">{ip}</code>
+          ) : (
+            <span className="text-xs text-muted-foreground">—</span>
+          );
+        },
+        size: 120,
+      },
+      {
+        id: "status",
+        header: "Status",
+        accessorFn: (vm) =>
+          vmStatus(
+            vm,
+            vmiByKey.get(vmKey(vm.metadata.namespace, vm.metadata.name)),
+          ).label,
+        cell: ({ row }) => {
+          const s = vmStatus(
+            row.original,
+            vmiByKey.get(
+              vmKey(row.original.metadata.namespace, row.original.metadata.name),
+            ),
+          );
+          return <StatusBadge status={s.label} tone={s.tone} />;
+        },
+        size: 140,
+      },
+      {
+        id: "age",
+        header: "Age",
+        accessorFn: (vm) => vm.metadata.creationTimestamp ?? "",
+        cell: ({ row }) => (
+          <span className="text-muted-foreground">
+            {age(row.original.metadata.creationTimestamp)}
+          </span>
+        ),
+        size: 80,
+      },
+    ],
+    [vmiByKey],
+  );
+
+  return (
+    <>
+      <ResourceTablePage<VirtualMachine>
+        icon={<Monitor />}
+        title="Virtual Machines"
+        description="Real VMs on the cluster — open-infra's EC2. Pick an OS and get a persistent disk, SSH (Linux) or RDP (Windows), and an optional LAN IP."
+        listPath={openinfraPaths.virtualmachines}
+        columns={columns}
+        search={(vm) => [vm.metadata.name, vm.metadata.namespace, vm.spec?.os]}
+        singular="Virtual Machine"
+        plural="Virtual Machines"
+        emptyTitle="No Virtual Machines yet"
+        emptyDescription="Create one, or scaffold with `open-infra init vm`."
+        onRowClick={(vm) =>
+          navigate({
+            to: "/vms/$namespace/$name",
+            params: {
+              namespace: vm.metadata.namespace ?? "default",
+              name: vm.metadata.name ?? "",
+            },
+          })
+        }
+        headerActions={
+          <Button onClick={() => setNewOpen(true)}>
+            <Plus className="size-4" />
+            New VM
+          </Button>
+        }
+      />
+      <NewVmDialog
+        open={newOpen}
+        onOpenChange={setNewOpen}
+        namespaces={namespaces}
+        defaultNamespace={scoped}
+        listPath={openinfraPaths.virtualmachines(scoped)}
+      />
+    </>
+  );
+}

--- a/ui/src/lib/k8s-paths.ts
+++ b/ui/src/lib/k8s-paths.ts
@@ -4,9 +4,12 @@ import {
   CNPG_GROUP,
   CNPG_VERSION,
   FUNCTIONS_PLURAL,
+  KUBEVIRT_GROUP,
+  KUBEVIRT_VERSION,
   MODELS_PLURAL,
   OPENINFRA_GROUP,
   OPENINFRA_VERSION,
+  VIRTUALMACHINES_PLURAL,
 } from "@/types/k8s";
 
 /**
@@ -49,6 +52,19 @@ export const openinfraPaths = {
   models: (ns?: string) => `${oiGV}${nsSegment(ns)}/${MODELS_PLURAL}`,
   model: (ns: string, name: string) =>
     `${oiGV}/namespaces/${ns}/${MODELS_PLURAL}/${name}`,
+  virtualmachines: (ns?: string) =>
+    `${oiGV}${nsSegment(ns)}/${VIRTUALMACHINES_PLURAL}`,
+  virtualmachine: (ns: string, name: string) =>
+    `${oiGV}/namespaces/${ns}/${VIRTUALMACHINES_PLURAL}/${name}`,
+};
+
+const kvGV = `/apis/${KUBEVIRT_GROUP}/${KUBEVIRT_VERSION}`;
+
+// KubeVirt VirtualMachineInstance — read-only live guest status (IP, phase).
+export const kubevirtPaths = {
+  vmis: (ns?: string) => `${kvGV}${nsSegment(ns)}/virtualmachineinstances`,
+  vmi: (ns: string, name: string) =>
+    `${kvGV}/namespaces/${ns}/virtualmachineinstances/${name}`,
 };
 
 export const cnpgPaths = {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -12,6 +12,8 @@ import { FunctionsPage } from "@/features/functions/functions-page";
 import { FunctionDetailPage } from "@/features/functions/function-detail-page";
 import { ModelsPage } from "@/features/models/models-page";
 import { ModelDetailPage } from "@/features/models/model-detail-page";
+import { VmsPage } from "@/features/vms/vms-page";
+import { VmDetailPage } from "@/features/vms/vm-detail-page";
 import { DatabasesPage } from "@/features/databases/databases-page";
 import { DatabaseDetailPage } from "@/features/databases/database-detail-page";
 import { ManagedDatabaseDetailPage } from "@/features/databases/managed-detail-page";
@@ -64,6 +66,18 @@ const modelDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/models/$namespace/$name",
   component: ModelDetailPage,
+});
+
+const vmsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/vms",
+  component: VmsPage,
+});
+
+const vmDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/vms/$namespace/$name",
+  component: VmDetailPage,
 });
 
 const databasesRoute = createRoute({
@@ -139,6 +153,8 @@ const routeTree = rootRoute.addChildren([
   functionDetailRoute,
   modelsRoute,
   modelDetailRoute,
+  vmsRoute,
+  vmDetailRoute,
   databasesRoute,
   databaseDetailRoute,
   managedDbDetailRoute,

--- a/ui/src/types/k8s.ts
+++ b/ui/src/types/k8s.ts
@@ -256,6 +256,43 @@ export type Model = K8sObject<ModelSpec, ModelStatus>;
 export const MODELS_PLURAL = "models";
 export const MODELS_CRD_NAME = "models.openinfra.dev";
 
+/* ---------------------- open-infra VirtualMachine CRD --------------------- */
+
+export interface VirtualMachineSpec {
+  os: string;
+  cpu?: number;
+  memory?: string;
+  diskSize?: string;
+  sshKey?: string;
+  expose?: boolean;
+  running?: boolean;
+}
+
+export interface VirtualMachineStatus {
+  os?: string;
+  ip?: string;
+  ready?: boolean;
+  conditions?: Condition[];
+}
+
+export type VirtualMachine = K8sObject<
+  VirtualMachineSpec,
+  VirtualMachineStatus
+>;
+export const VIRTUALMACHINES_PLURAL = "virtualmachines";
+export const VIRTUALMACHINES_CRD_NAME = "virtualmachines.openinfra.dev";
+
+// KubeVirt VirtualMachineInstance — the running guest. The console reads it
+// (read-only) for live status: IP + phase. Backs the VM's connection + console.
+export const KUBEVIRT_GROUP = "kubevirt.io";
+export const KUBEVIRT_VERSION = "v1";
+export interface VmiStatus {
+  phase?: string;
+  nodeName?: string;
+  interfaces?: { ipAddress?: string; name?: string }[];
+}
+export type Vmi = K8sObject<unknown, VmiStatus>;
+
 /* ---------------------- CloudNativePG managed Postgres -------------------- */
 
 export interface CnpgClusterSpec {


### PR DESCRIPTION
Closes #21. Adds open-infra's **EC2**: a fourth public abstraction, `kind: VirtualMachine`, backed by **KubeVirt** + **CDI**. Pick an OS, get a real VM with a persistent disk, first-boot login, and native access.

### Abstraction
- **XRD** `xvirtualmachines.openinfra.dev`: OS catalog (`ubuntu-24.04/22.04`, `fedora-40`, `debian-12`, `centos-stream-9`, `windows`), `cpu`/`memory`/`diskSize`, `sshKey`, `expose`, `running`.
- **Composition**: KubeVirt VM + `dataVolumeTemplate` (CDI imports the Linux cloud image / clones the Windows golden image), first-boot config (cloud-init for Linux; cloudbase-init PowerShell sets the per-VM admin password + RDP for Windows), a Service, connection Secret (`<name>-vm`), optional LAN LoadBalancer. `spec.running` → `runStrategy` so the console Start/Stop never fights the provider.
- Provider RBAC gains `kubevirt.io`/`cdi.kubevirt.io`.

### Install
- `install.sh` installs **KubeVirt v1.8.4 + CDI v1.65.0** (like MetalLB), gated by `components.virtualization` (default on). Needs `/dev/kvm` on the nodes.

### Console
- New **Virtual Machines** view: list (OS, size, live IP + status), New VM dialog (OS catalog + sizing + SSH key + expose), detail (Overview, **Access** = native SSH / `mstsc`-RDP + revealable generated password + port-forward + LAN endpoint, Monitoring, YAML), Start/Stop, Danger Zone.
- **No web/VNC console** — access is native SSH/RDP; no noVNC dependency.

### Windows
- `scripts/build-windows-image.sh` + `scripts/windows/{autounattend.xml,setup.ps1}`: one-time golden-image build from a **Microsoft eval ISO** (virtio + cloudbase-init + sysprep). `docs/virtual-machines.md` covers it, incl. licensing (eval = non-production only).

### Validation (live, 3-node cluster)
- All nodes have `/dev/kvm` + VT-x. KubeVirt + CDI `Deployed`.
- An `ubuntu-24.04` claim provisions end-to-end: CDI import (~90s) → boot → cloud-init → **SSH login as `openinfra`** confirmed.
- Windows branch renders (`rdp` / `Administrator` / LAN `3389`); its disk is the documented BYO golden-image step.
- `tsc` + production build green.

Follow-up: Workspaces (#30) builds desktops on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)