### PR TITLE
feat: expose any resource to the LAN + VM bridge networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ end-to-end:
   catalog (Linux + Windows), persistent disk, SSH/RDP. See
   [`docs/virtual-machines.md`](docs/virtual-machines.md).
 
+**Reach anything from the LAN.** Every resource takes `expose: true` to get a
+real LAN IP (MetalLB LoadBalancer) — Applications, Models, Databases, VMs;
+Functions are LAN-reachable via the Knative gateway (`expose: false` makes them
+cluster-local). VMs can also go fully on-LAN with `network: bridge` (a real DHCP
+lease, no NAT).
+
 The build history and phase plan live in [`docs/roadmap.md`](docs/roadmap.md).
 
 > **Note:** Redis currently pins Bitnami's legacy image mirror as a stopgap

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,6 +32,15 @@ networking:
   # Ingress controller bundled with k3s. Keep traefik for v1.
   ingress: traefik
 
+  # Direct-LAN networking for VMs (kind: VirtualMachine, network: bridge): attach
+  # VMs to the physical LAN via Multus + macvlan so they pull a real DHCP lease —
+  # a first-class LAN host, no MetalLB/NAT. Opt-in; enable with scripts/enable-vm-lan.sh
+  # (installs Multus — a cluster CNI change). 'interface' is the LAN NIC on the
+  # nodes that will host bridged VMs (label them openinfra.dev/vm-lan=true).
+  vmLan:
+    enabled: false
+    interface: eno1             # your LAN NIC (e.g. eno1 / enp4s0) — may differ per node
+
 dns:
   # "sslip"     -> zero-config magic DNS: <app>.<lb-ip>.sslip.io  (great for dev)
   # "cloudflare"-> real public DNS via Cloudflare (see edge: below)

--- a/docs/virtual-machines.md
+++ b/docs/virtual-machines.md
@@ -71,6 +71,48 @@ stopped.
 > Web (in-browser) console is intentionally **not** provided — access is native
 > SSH / RDP, so there is no extra in-cluster console dependency to run.
 
+## Networking: NAT vs direct-LAN (bridge)
+
+`spec.network` controls how the VM attaches:
+
+- **`masquerade`** (default) — the VM sits behind the pod network (NAT). Reach it
+  in-cluster via its `Service`, or from the LAN via `expose: true` (a MetalLB
+  LoadBalancer hands it a LAN IP). The pod overlay (`10.42/16`) is **not** routable
+  from your LAN, which is why a raw pod IP isn't reachable from a workstation.
+- **`bridge`** — the VM joins the **physical LAN directly** (Multus + macvlan) and
+  pulls a real **DHCP lease** from your router. It's a first-class LAN host — no
+  MetalLB, no NAT.
+
+### Enabling bridge mode (one-time, operator)
+
+Bridge mode needs Multus (a cluster CNI change), so it's opt-in:
+
+```sh
+# sets networking.vmLan.interface in config.yaml, or pass --interface
+scripts/enable-vm-lan.sh --interface eno1
+# then label the nodes whose LAN NIC matches (bridged VMs schedule only there):
+kubectl label node <node> openinfra.dev/vm-lan=true
+```
+
+The script installs Multus + the macvlan plugin (k3s paths), self-tests that new
+pods still get networking, and creates the `default/openinfra-lan`
+NetworkAttachmentDefinition (macvlan, no IPAM → guest DHCP). Then:
+
+```yaml
+spec:
+  os: ubuntu-24.04
+  network: bridge        # real LAN IP via DHCP
+```
+
+**Caveats**
+- **NIC names may differ per node** (e.g. `eno1` vs `enp4s0`); the NAD has one
+  `master`, so label only nodes whose LAN NIC matches it (the VM gets a node
+  affinity to `openinfra.dev/vm-lan=true`).
+- **macvlan limitation**: the *host node* cannot talk to its own bridged VMs
+  (other LAN hosts can) — a kernel macvlan property.
+- The VM still keeps a pod NIC (eth0) for in-cluster/Service access; the LAN lease
+  lands on eth1.
+
 ## Windows: build the golden image once
 
 Windows has no redistributable cloud image, so you build a reusable **golden

--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -135,6 +135,29 @@ spec:
                   spec:
                     selector: { app.kubernetes.io/name: {{ $name }} }
                     ports: [ { port: 80, targetPort: {{ $spec.port }} } ]
+            {{- if $spec.expose }}
+            ---
+            # --- LAN LoadBalancer (MetalLB): the app's port on a LAN IP, for raw
+            #     TCP / non-HTTP / no-DNS access (alongside any Ingress). ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: app-lan
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: {{ $name }}-lan
+                    namespace: {{ $ns }}
+                    labels: { openinfra.dev/app-lan: {{ $name }} }
+                  spec:
+                    type: LoadBalancer
+                    selector: { app.kubernetes.io/name: {{ $name }} }
+                    ports: [ { port: {{ $spec.port }}, targetPort: {{ $spec.port }} } ]
+            {{- end }}
             {{- if $spec.domain }}
             ---
             # --- Ingress (Traefik) + TLS via cert-manager ---

--- a/platform/abstraction/function-composition.yaml
+++ b/platform/abstraction/function-composition.yaml
@@ -32,6 +32,9 @@ spec:
             {{- $ns := (index $labels "crossplane.io/claim-namespace") | default "default" }}
             {{- $scaling := $spec.scaling | default dict }}
             {{- $gpu := $spec.gpu | default 0 }}
+            {{- /* expose defaults true; hasKey check (Sprig default treats false
+                   as empty). false -> cluster-local (in-cluster only). */}}
+            {{- $expose := true }}{{- if hasKey $spec "expose" }}{{- $expose = $spec.expose }}{{- end }}
             ---
             # --- Knative Service: the scale-to-zero "Function" ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
@@ -47,7 +50,12 @@ spec:
                   metadata:
                     name: {{ $name }}
                     namespace: {{ $ns }}
-                    labels: { app.kubernetes.io/name: {{ $name }} }
+                    labels:
+                      app.kubernetes.io/name: {{ $name }}
+                      {{- if not $expose }}
+                      # Private: only reachable from inside the cluster.
+                      networking.knative.dev/visibility: cluster-local
+                      {{- end }}
                   spec:
                     template:
                       metadata:

--- a/platform/abstraction/function-xrd.yaml
+++ b/platform/abstraction/function-xrd.yaml
@@ -37,6 +37,9 @@ spec:
                 image: { type: string, description: "Container image that serves HTTP (CI replaces the tag)" }
                 port:  { type: integer, default: 8080, description: "Container port the function listens on" }
                 gpu:   { type: integer, default: 0, description: "GPUs per instance (serverless inference); 0 = CPU" }
+                # Reachable on the LAN via the Knative gateway (default). Set false
+                # to make the function cluster-local (in-cluster callers only).
+                expose: { type: boolean, default: true }
                 scaling:
                   type: object
                   properties:

--- a/platform/abstraction/model-composition.yaml
+++ b/platform/abstraction/model-composition.yaml
@@ -200,6 +200,29 @@ spec:
                   spec:
                     selector: { app.kubernetes.io/name: {{ $name }} }
                     ports: [ { port: 80, targetPort: 8080 } ]
+            {{- if $spec.expose }}
+            ---
+            # --- LAN LoadBalancer (MetalLB): the inference endpoint on a LAN IP,
+            #     so workstations hit the OpenAI API without DNS/Ingress. ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: model-lan
+            spec:
+              forProvider:
+                manifest:
+                  apiVersion: v1
+                  kind: Service
+                  metadata:
+                    name: {{ $name }}-lan
+                    namespace: {{ $ns }}
+                    labels: { openinfra.dev/model-lan: {{ $name }} }
+                  spec:
+                    type: LoadBalancer
+                    selector: { app.kubernetes.io/name: {{ $name }} }
+                    ports: [ { port: 80, targetPort: 8080 } ]
+            {{- end }}
             ---
             # --- Connection Secret consumers reference (cf. the DB secret) ---
             apiVersion: kubernetes.crossplane.io/v1alpha2

--- a/platform/abstraction/model-xrd.yaml
+++ b/platform/abstraction/model-xrd.yaml
@@ -51,6 +51,9 @@ spec:
                 highAvailability: { type: boolean, default: false }
                 domain:      { type: string, description: "Hostname for external Ingress + TLS" }
                 storageSize: { type: string, default: "20Gi", description: "Ephemeral weight-cache size limit (emptyDir)" }
+                # Expose the inference endpoint on a LAN IP (MetalLB LoadBalancer) so
+                # workstations can hit the OpenAI-compatible API without DNS/Ingress.
+                expose:      { type: boolean, default: false }
             status:
               type: object
               properties:

--- a/platform/abstraction/vm-composition.yaml
+++ b/platform/abstraction/vm-composition.yaml
@@ -58,6 +58,7 @@ spec:
             {{- $isWin := eq $profile.osType "windows" }}
             {{- $port := 22 }}{{- $user := "openinfra" }}{{- $proto := "ssh" }}
             {{- if $isWin }}{{- $port = 3389 }}{{- $user = "Administrator" }}{{- $proto = "rdp" }}{{- end }}
+            {{- $bridge := eq ($spec.network | default "masquerade") "bridge" }}
             ---
             # --- The VM. dataVolumeTemplates provisions the persistent root disk via
             #     CDI (registry import for Linux; clone of the golden PVC for Windows).
@@ -107,6 +108,16 @@ spec:
                           kubevirt.io/domain: {{ $name }}
                           app.kubernetes.io/name: {{ $name }}
                       spec:
+                        {{- if $bridge }}
+                        # Bridge VMs must land where the macvlan parent NIC exists
+                        # (label those nodes openinfra.dev/vm-lan=true).
+                        affinity:
+                          nodeAffinity:
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              nodeSelectorTerms:
+                                - matchExpressions:
+                                    - { key: openinfra.dev/vm-lan, operator: In, values: ["true"] }
+                        {{- end }}
                         domain:
                           cpu:
                             cores: {{ $cpu }}
@@ -144,10 +155,20 @@ spec:
                             interfaces:
                               - name: default
                                 masquerade: {}
+                              {{- if $bridge }}
+                              # Second NIC bridged onto the physical LAN (macvlan).
+                              - name: lan
+                                bridge: {}
+                              {{- end }}
                             networkInterfaceMultiqueue: true
                         networks:
                           - name: default
                             pod: {}
+                          {{- if $bridge }}
+                          - name: lan
+                            multus:
+                              networkName: default/openinfra-lan
+                          {{- end }}
                         volumes:
                           - name: root
                             dataVolume:
@@ -186,6 +207,14 @@ spec:
                                 runcmd:
                                   - [systemctl, enable, --now, qemu-guest-agent]
                                 {{- end }}
+                              {{- if $bridge }}
+                              # DHCP both NICs: eth0 (pod) + eth1 (LAN bridge).
+                              networkData: |
+                                version: 2
+                                ethernets:
+                                  eth0: { dhcp4: true }
+                                  eth1: { dhcp4: true }
+                              {{- end }}
             ---
             # --- Service: in-cluster reach to SSH (Linux) / RDP (Windows). ---
             apiVersion: kubernetes.crossplane.io/v1alpha2

--- a/platform/abstraction/vm-xrd.yaml
+++ b/platform/abstraction/vm-xrd.yaml
@@ -58,6 +58,17 @@ spec:
                 # Reach the VM on a LAN IP (MetalLB): SSH (22) for Linux, RDP (3389)
                 # for Windows. Off by default — port-forward / web console otherwise.
                 expose:   { type: boolean, default: false }
+                # Network attachment:
+                #   masquerade (default) — VM behind the pod network (NAT); reach it
+                #     in-cluster via its Service, or from the LAN via expose/MetalLB.
+                #   bridge — VM joins the physical LAN directly via Multus+macvlan and
+                #     pulls a real DHCP lease (a first-class LAN host, no MetalLB/NAT).
+                #     Requires networking.vmLan enabled at install (Multus) and nodes
+                #     labelled openinfra.dev/vm-lan=true. See docs/virtual-machines.md.
+                network:
+                  type: string
+                  enum: [masquerade, bridge]
+                  default: masquerade
                 # Power state. The console's Start/Stop flips this; the Composition
                 # maps it to KubeVirt runStrategy (Always/Halted). Disk is retained
                 # when stopped. Kept in spec (not a subresource) so it stays GitOps-

--- a/platform/abstraction/xrd.yaml
+++ b/platform/abstraction/xrd.yaml
@@ -41,6 +41,9 @@ spec:
                 image:   { type: string, description: "Container image (omit for a data-only app)" }
                 port:    { type: integer, description: "Container port the app listens on" }
                 domain:  { type: string, description: "Hostname for Ingress + TLS + DNS" }
+                # Expose the app's port directly on a LAN IP (MetalLB LoadBalancer),
+                # in addition to any Ingress — for raw TCP / non-HTTP / no-DNS access.
+                expose:  { type: boolean, default: false }
                 scaling:
                   type: object
                   properties:

--- a/scripts/enable-vm-lan.sh
+++ b/scripts/enable-vm-lan.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────
+# Enable direct-LAN networking for VMs (kind: VirtualMachine, network: bridge).
+#
+#   scripts/enable-vm-lan.sh [--interface eno1] [--dry-run]
+#
+# This is an OPT-IN, network-sensitive step (kept out of install.sh): it installs
+# Multus as the cluster's primary CNI (delegating to the existing flannel), adds
+# the macvlan reference plugin, and creates a NetworkAttachmentDefinition that
+# bridges VMs onto your physical LAN so they pull a real DHCP lease.
+#
+# Blast radius: existing pods keep their networking; a misconfigured Multus only
+# affects NEW pod creation (recoverable). This script self-tests new-pod
+# networking after install and prints rollback steps if it regresses.
+#
+# After it succeeds: label the nodes whose LAN NIC matches --interface
+#   kubectl label node <node> openinfra.dev/vm-lan=true
+# then create VMs with `network: bridge`.
+# ─────────────────────────────────────────────────────────────
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="${REPO_DIR}/config.yaml"
+MULTUS_VERSION="v4.1.0"
+CNI_PLUGINS_VERSION="v1.5.1"
+IFACE=""; DRY_RUN=0
+LOG() { printf '\033[1;36m[vm-lan]\033[0m %s\n' "$*"; }
+WARN(){ printf '\033[1;33m[warn]\033[0m %s\n' "$*" >&2; }
+DIE() { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do case "$1" in
+  --interface) IFACE="$2"; shift 2 ;;
+  --dry-run) DRY_RUN=1; shift ;;
+  -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -20; exit 0 ;;
+  *) DIE "unknown arg: $1" ;;
+esac; done
+
+command -v kubectl >/dev/null || DIE "kubectl is required"
+# Fall back to config.yaml networking.vmLan.interface.
+if [ -z "$IFACE" ] && [ -f "$CONFIG" ]; then
+  IFACE="$(awk '/^  vmLan:/{f=1} f&&/interface:/{sub(/.*interface:[ ]*/,"");sub(/[ ]*#.*/,"");print;exit}' "$CONFIG")"
+fi
+[ -n "$IFACE" ] || DIE "no LAN interface — pass --interface <nic> or set networking.vmLan.interface"
+LOG "LAN interface (macvlan parent): $IFACE"
+RUN(){ if [ "$DRY_RUN" = 1 ]; then printf '  + %s\n' "$*"; else eval "$@"; fi; }
+
+K3S_CNI_BIN="/var/lib/rancher/k3s/data/current/bin"
+K3S_CNI_CONF="/var/lib/rancher/k3s/agent/etc/cni/net.d"
+
+# 1. Install the reference CNI plugins (macvlan, static, tuning) into k3s' bin dir
+#    via a one-shot DaemonSet (k3s ships only a minimal set).
+LOG "installing CNI reference plugins ${CNI_PLUGINS_VERSION} (macvlan…)"
+RUN "cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata: { name: install-cni-plugins, namespace: kube-system }
+spec:
+  selector: { matchLabels: { app: install-cni-plugins } }
+  template:
+    metadata: { labels: { app: install-cni-plugins } }
+    spec:
+      hostNetwork: true
+      tolerations: [ { operator: Exists } ]
+      initContainers:
+        - name: install
+          image: curlimages/curl:8.10.1
+          securityContext: { runAsUser: 0 }
+          command: [sh, -c]
+          args:
+            - |
+              set -e
+              cd /tmp
+              curl -sfL https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz | tar xz
+              for p in macvlan static tuning host-local; do cp -f \\\$p /host/bin/ && echo installed \\\$p; done
+          volumeMounts: [ { name: bin, mountPath: /host/bin } ]
+      containers:
+        - name: pause
+          image: registry.k8s.io/pause:3.9
+      volumes:
+        - name: bin
+          hostPath: { path: ${K3S_CNI_BIN} }
+EOF"
+RUN "kubectl -n kube-system rollout status ds/install-cni-plugins --timeout=180s || true"
+
+# 2. Install Multus (thick), pointed at k3s' CNI paths. Multus becomes the primary
+#    CNI and delegates the default network to the existing flannel config.
+LOG "installing Multus ${MULTUS_VERSION} (k3s paths)"
+RUN "curl -sfL https://raw.githubusercontent.com/k8snetworkplumbingwg/multus-cni/${MULTUS_VERSION}/deployments/multus-daemonset-thick.yml \
+  | sed -e 's#/etc/cni/net.d#${K3S_CNI_CONF}#g' -e 's#/opt/cni/bin#${K3S_CNI_BIN}#g' \
+  | kubectl apply -f -"
+RUN "kubectl -n kube-system rollout status ds/kube-multus-ds --timeout=180s || true"
+
+# 3. Self-test: a NEW pod must still get networking (proves Multus delegates OK).
+if [ "$DRY_RUN" = 0 ]; then
+  LOG "self-test: scheduling a throwaway pod to confirm new-pod networking…"
+  kubectl run vmlan-selftest --image=busybox:1.36 --restart=Never -- sleep 30 >/dev/null 2>&1 || true
+  if kubectl wait --for=condition=Ready pod/vmlan-selftest --timeout=60s >/dev/null 2>&1; then
+    LOG "✅ new pods still get networking — Multus is delegating correctly."
+    kubectl delete pod vmlan-selftest --wait=false >/dev/null 2>&1 || true
+  else
+    kubectl delete pod vmlan-selftest --wait=false >/dev/null 2>&1 || true
+    WARN "new-pod networking FAILED after Multus install. Roll back on each node:"
+    WARN "  sudo rm ${K3S_CNI_CONF}/00-multus.conf*; kubectl -n kube-system delete ds kube-multus-ds"
+    DIE "aborting before creating the NAD — fix or roll back first."
+  fi
+fi
+
+# 4. The NetworkAttachmentDefinition: macvlan onto the LAN NIC, NO IPAM — the VM
+#    guest pulls its own DHCP lease from the LAN router.
+LOG "creating NetworkAttachmentDefinition default/openinfra-lan (master=$IFACE)"
+RUN "cat <<EOF | kubectl apply -f -
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata: { name: openinfra-lan, namespace: default }
+spec:
+  config: |
+    {
+      \"cniVersion\": \"0.3.1\",
+      \"type\": \"macvlan\",
+      \"master\": \"${IFACE}\",
+      \"mode\": \"bridge\",
+      \"ipam\": {}
+    }
+EOF"
+
+cat <<NEXT
+
+✅ VM LAN networking enabled.
+
+Next:
+  1. Label the nodes whose LAN NIC is '${IFACE}' (bridged VMs schedule only there):
+       kubectl label node <node> openinfra.dev/vm-lan=true
+     (NICs may differ per node — check with: ip route show default)
+  2. Create a VM with  network: bridge  (or pick "Bridged to LAN" in the console).
+     The guest pulls a real LAN DHCP lease; reach it directly, no MetalLB.
+
+Note: macvlan does not allow the *host node* to talk to its own bridged VMs
+(other LAN hosts can). See docs/virtual-machines.md.
+NEXT
+LOG "done."

--- a/ui/src/features/vms/new-vm-dialog.tsx
+++ b/ui/src/features/vms/new-vm-dialog.tsx
@@ -58,6 +58,7 @@ export function NewVmDialog({
   const [diskSize, setDiskSize] = useState("20Gi");
   const [sshKey, setSshKey] = useState("");
   const [expose, setExpose] = useState(false);
+  const [network, setNetwork] = useState("masquerade");
   const [touched, setTouched] = useState(false);
 
   const isWindows = osFamily(os) === "windows";
@@ -70,6 +71,7 @@ export function NewVmDialog({
     setDiskSize("20Gi");
     setSshKey("");
     setExpose(false);
+    setNetwork("masquerade");
     setTouched(false);
     createMutation.reset();
   }
@@ -105,6 +107,7 @@ export function NewVmDialog({
         diskSize: diskSize || "20Gi",
         ...(sshKey.trim() && !isWindows ? { sshKey: sshKey.trim() } : {}),
         expose,
+        network,
       },
     } as K8sObject);
   };
@@ -203,16 +206,31 @@ export function NewVmDialog({
             />
           </div>
           <div className="space-y-1.5">
+            <Label htmlFor="vm-net">Network</Label>
+            <Select value={network} onValueChange={setNetwork}>
+              <SelectTrigger id="vm-net">
+                <SelectValue placeholder="Network" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="masquerade">Pod NAT (default)</SelectItem>
+                <SelectItem value="bridge">Bridged to LAN (direct IP)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
             <Label>LAN access</Label>
             <label className="flex h-9 items-center gap-2 text-sm">
               <input
                 type="checkbox"
                 checked={expose}
+                disabled={network === "bridge"}
                 onChange={(e) => setExpose(e.target.checked)}
-                className="size-4 accent-primary"
+                className="size-4 accent-primary disabled:opacity-50"
               />
               <span className="text-muted-foreground">
-                {isWindows ? "RDP (3389)" : "SSH (22)"} on a LAN IP
+                {network === "bridge"
+                  ? "already on the LAN (bridged)"
+                  : `${isWindows ? "RDP (3389)" : "SSH (22)"} on a LAN IP`}
               </span>
             </label>
           </div>


### PR DESCRIPTION
Addresses the directive that **LAN exposure is a first-class choice on every resource type** — and adds the direct-LAN (bridge) option for VMs.

## `expose` everywhere (real LAN IP via MetalLB)
| Resource | Before | Now |
|---|---|---|
| Database | ✅ | ✅ |
| VirtualMachine | ✅ | ✅ |
| **Application** | ❌ (Ingress only) | `spec.expose` → `<name>-lan` LoadBalancer on the app's port |
| **Model** | ❌ | `spec.expose` → `<name>-lan` LoadBalancer on the endpoint |
| **Function** | external by default | `spec.expose` (default `true`); `false` → Knative `cluster-local` |

Data-only Applications correctly skip the workload LB. Model/Function create forms are schema-driven, so the new `expose` field appears automatically.

## VM `network: bridge` (direct LAN, no NAT)
`spec.network: masquerade` (default) | `bridge`. Bridge attaches the VM to the physical LAN via **Multus + macvlan**; the guest pulls a real **DHCP lease** — a first-class LAN host. The composition adds the multus interface (bridge binding), DHCP `networkData`, and a node affinity to `openinfra.dev/vm-lan=true` (NIC names differ per node — cake/cakenas `eno1`, mlbox `enp4s0`).

Enablement is **opt-in** (it changes the cluster CNI), kept out of `install.sh`:
- `scripts/enable-vm-lan.sh` installs Multus + the macvlan plugin (k3s paths), **self-tests new-pod networking** with rollback notes, and creates `default/openinfra-lan` (macvlan, no IPAM → guest DHCP).
- `config: networking.vmLan {enabled, interface}`; console **New VM** gets a Network picker; `docs/virtual-machines.md` documents NAT vs bridge + the macvlan host↔VM caveat.

## Why this answers "why couldn't I reach the pod IP?"
The pod IP (`10.42/16`) is a flannel overlay routable only on cluster nodes. `expose` (MetalLB) or `bridge` (macvlan DHCP) gives a real LAN address; that's now available on every resource.

## Validation
- Offline Sprig render of all four compositions: `app-lan`/`model-lan` LBs appear with `expose`, data-only apps skip the LB, Function toggles `cluster-local`, VM renders the bridge interface.
- `kubectl apply --dry-run=server` on every edited XRD + Composition.
- Console `tsc` + production build green; `enable-vm-lan.sh` shellcheck-clean.

> The Multus install can't be validated here (no node root); it's the operator's deliberate opt-in step with a built-in self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)