### PR TITLE
fix(vm): openinfra-images namespace (GitOps) + surface VM Images build errors

### DIFF
--- a/platform/abstraction/images-namespace.yaml
+++ b/platform/abstraction/images-namespace.yaml
@@ -1,0 +1,10 @@
+# Namespace for VM golden images: kind: VmImage builders (installer VMs, imported
+# ISOs) and the <os>-golden PVCs that Windows VMs clone cross-namespace. Declared
+# here (synced with the abstraction) so it always exists — the console's VM Images
+# build targets it, and a missing namespace would fail the build.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openinfra-images
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/ui/src/features/vms/vm-images-page.tsx
+++ b/ui/src/features/vms/vm-images-page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/common/status-badge";
 import { useK8sWatch, watchQueryKey } from "@/hooks/use-k8s-watch";
 import { corePaths, kubevirtPaths, openinfraPaths } from "@/lib/k8s-paths";
-import { k8sCreate, k8sDelete } from "@/lib/api";
+import { ApiError, k8sCreate, k8sDelete } from "@/lib/api";
 import type { StatusTone } from "@/lib/format";
 import {
   OPENINFRA_GROUP,
@@ -88,6 +88,14 @@ export function VmImagesPage() {
         only</strong> (180 days). A build downloads a ~5&nbsp;GB ISO and runs an
         unattended install — expect 20–40 minutes.
       </div>
+      {build.error || remove.error ? (
+        <div className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {(() => {
+            const e = build.error ?? remove.error;
+            return e instanceof ApiError ? e.message : "Action failed.";
+          })()}
+        </div>
+      ) : null}
 
       <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {WINDOWS_CATALOG.map((os) => {


### PR DESCRIPTION
Clicking **Build** on VM Images "flashed and nothing happened." Root cause: `VmImage` claims target the **`openinfra-images`** namespace, which was only created by `install.sh` — on this cluster the platform was Argo-synced and `install.sh` never ran, so the namespace was missing and the create 404'd. The page had no error display, so it failed silently.

- **Declare `openinfra-images` as a GitOps Namespace** (`platform/abstraction/images-namespace.yaml`, sync-wave 1) so it always exists when the abstraction is present — not dependent on `install.sh`.
- **VM Images page surfaces errors** — a red banner on a failed build/remove instead of a silent flash.

(The namespace has been created on the live cluster already, so Build works now; this makes it permanent + declarative.)

`tsc` + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)