### PR TITLE
fix(console): LAN access needs no commands — hide bridge unless enabled

### DIFF
--- a/ui/src/features/vms/new-vm-dialog.tsx
+++ b/ui/src/features/vms/new-vm-dialog.tsx
@@ -262,18 +262,16 @@ export function NewVmDialog({
                   LAN IP — reach {isWindows ? "RDP (3389)" : "SSH (22)"} from your
                   network (MetalLB)
                 </SelectItem>
-                <SelectItem value="bridge" disabled={!bridgeReady}>
-                  Direct on LAN — real DHCP address
-                  {!bridgeReady ? " (needs enabling)" : ""}
-                </SelectItem>
+                {/* Bridge is an advanced cluster-CNI mode; only offer it when an
+                    operator has enabled it. Everyday LAN access is "LAN IP" above,
+                    which needs no setup. */}
+                {bridgeReady ? (
+                  <SelectItem value="bridge">
+                    Direct on LAN — real DHCP address
+                  </SelectItem>
+                ) : null}
               </SelectContent>
             </Select>
-            {!bridgeReady ? (
-              <p className="text-xs text-muted-foreground">
-                "Direct on LAN" needs{" "}
-                <code>networking.vmLan.enabled</code> + <code>./install.sh</code>.
-              </p>
-            ) : null}
           </div>
           {isWindows ? (
             <div className="sm:col-span-2 rounded-md border border-warning/40 bg-warning/10 p-3 text-xs text-muted-foreground">


### PR DESCRIPTION
Choosing **LAN IP** for a VM still showed *""Direct on LAN" needs networking.vmLan.enabled + ./install.sh"* — making LAN access look like it requires the CLI. It doesn't: **"LAN IP (MetalLB)" works entirely from the UI, no commands** (it just provisions a LoadBalancer for a real `192.168.254.x` address).

The only command-requiring option was **"Direct on LAN" (bridge)** — a cluster-CNI change. Dangling it greyed-out with an `install.sh` hint is what caused the confusion.

Fix: **hide "Direct on LAN" entirely unless bridge is actually enabled** (a labelled node). The New VM network dropdown now shows only what works with zero setup — **In-cluster only** + **LAN IP** — and bridge appears only on clusters where it'll function.

`tsc` + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)