### PR TITLE
feat(console): live install screen on VM Images (watch the build via noVNC)

### DIFF
--- a/platform/console/manifests/rbac.yaml
+++ b/platform/console/manifests/rbac.yaml
@@ -89,6 +89,13 @@ rules:
     resources:
       - datavolumes
     verbs: [get, list, watch]
+  # VNC of installer VMs — the BFF reverse-proxies this websocket (served by
+  # virt-api) so the VM Images page can show a live build screen. Scoped to the
+  # vnc subresource only (not console/exec).
+  - apiGroups: [subresources.kubevirt.io]
+    resources:
+      - virtualmachineinstances/vnc
+    verbs: [get]
 
   # ── CloudNativePG: read managed Postgres clusters (the Databases view) ──────
   - apiGroups: [postgresql.cnpg.io]

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@novnc/novnc": "^1.7.0",
         "@radix-ui/react-dialog": "1.1.17",
         "@radix-ui/react-dropdown-menu": "2.1.18",
         "@radix-ui/react-label": "2.1.10",
@@ -183,6 +184,12 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@novnc/novnc": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.7.0.tgz",
+      "integrity": "sha512-ucEJOx4T2avIRCleodk7YobZj5O2Ga2AeLfQ69A/yjG9HHba2+PDgwSkN3FttrmG+70ZGx21sElNFouK13RzyA==",
+      "license": "MPL-2.0"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
@@ -1101,9 +1108,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1121,9 +1125,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1141,9 +1142,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,9 +1159,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1181,9 +1176,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1201,9 +1193,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1430,9 +1419,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,9 +1436,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1470,9 +1453,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1490,9 +1470,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2271,9 +2248,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2295,9 +2269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2319,9 +2290,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2343,9 +2311,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,7 @@
     "lint": "tsc -b --noEmit"
   },
   "dependencies": {
+    "@novnc/novnc": "1.7.0",
     "@radix-ui/react-dialog": "1.1.17",
     "@radix-ui/react-dropdown-menu": "2.1.18",
     "@radix-ui/react-label": "2.1.10",

--- a/ui/src/features/vms/installer-vnc.tsx
+++ b/ui/src/features/vms/installer-vnc.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import RFB from "@novnc/novnc";
+import { kubevirtPaths } from "@/lib/k8s-paths";
+
+/**
+ * Live (view-only) VNC of an installer VM, so VM Images can show a Windows build
+ * as it installs. Connects noVNC to the KubeVirt VMI /vnc websocket via the BFF's
+ * same-origin /api/k8s proxy (which injects the SA token). KubeVirt streams raw
+ * RFB under the `plain.kubevirt.io` subprotocol.
+ */
+export function InstallerVnc({
+  namespace,
+  name,
+}: {
+  namespace: string;
+  name: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<"connecting" | "connected" | "error">(
+    "connecting",
+  );
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setStatus("connecting");
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const url = `${proto}//${window.location.host}/api/k8s${kubevirtPaths.vnc(
+      namespace,
+      name,
+    )}`;
+    let rfb: RFB | null = null;
+    try {
+      rfb = new RFB(el, url, { wsProtocols: ["plain.kubevirt.io"] });
+      rfb.viewOnly = true; // watch-only; the install is unattended
+      rfb.scaleViewport = true;
+      rfb.background = "#000";
+      rfb.addEventListener("connect", () => setStatus("connected"));
+      rfb.addEventListener("disconnect", () => setStatus("error"));
+    } catch {
+      setStatus("error");
+    }
+    return () => {
+      try {
+        rfb?.disconnect();
+      } catch {
+        /* already gone */
+      }
+    };
+  }, [namespace, name]);
+
+  return (
+    <div className="space-y-1">
+      <div
+        ref={ref}
+        className="aspect-video w-full overflow-hidden rounded-md border border-border bg-black"
+      />
+      {status !== "connected" ? (
+        <p className="text-xs text-muted-foreground">
+          {status === "connecting"
+            ? "Connecting to the install screen…"
+            : "Console not available yet — the installer VM may still be starting."}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/features/vms/vm-images-page.tsx
+++ b/ui/src/features/vms/vm-images-page.tsx
@@ -21,6 +21,7 @@ import {
   WINDOWS_CATALOG,
   goldenPvcName,
 } from "./vm-shared";
+import { InstallerVnc } from "./installer-vnc";
 
 type Pvc = K8sObject<unknown, { phase?: string }>;
 
@@ -97,54 +98,81 @@ export function VmImagesPage() {
         </div>
       ) : null}
 
-      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {WINDOWS_CATALOG.map((os) => {
-          const claim = byName.im.get(os.value);
-          const installer = byName.inst.get(`${os.value}-installer`);
-          const golden = byName.gold.get(goldenPvcName(os.value));
-          const st = buildState(claim, installer, golden);
-          return (
-            <Card key={os.value}>
-              <CardContent className="space-y-3 p-4">
-                <div className="flex items-center justify-between">
-                  <span className="font-medium">{os.label}</span>
-                  <StatusBadge status={st.label} tone={st.tone} />
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  {st.state === "ready"
-                    ? `Available as os: ${os.value} when you create a VM.`
-                    : st.state === "building"
-                      ? "Importing the ISO + running the unattended install…"
-                      : "Not built yet."}
-                </p>
-                {st.state === "none" ? (
-                  <Button
-                    size="sm"
-                    onClick={() => build.mutate(os.value)}
-                    disabled={build.isPending}
-                  >
-                    <Plus className="size-4" /> Build
-                  </Button>
-                ) : (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => remove.mutate(os.value)}
-                    disabled={remove.isPending}
-                  >
-                    {st.state === "building" ? (
-                      <Loader2 className="size-4 animate-spin" />
+      {(() => {
+        const rows = WINDOWS_CATALOG.map((os) => ({
+          os,
+          st: buildState(
+            byName.im.get(os.value),
+            byName.inst.get(`${os.value}-installer`),
+            byName.gold.get(goldenPvcName(os.value)),
+          ),
+        }));
+        const building = rows.filter((r) => r.st.state === "building");
+        return (
+          <>
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {rows.map(({ os, st }) => (
+                <Card key={os.value}>
+                  <CardContent className="space-y-3 p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">{os.label}</span>
+                      <StatusBadge status={st.label} tone={st.tone} />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {st.state === "ready"
+                        ? `Available as os: ${os.value} when you create a VM.`
+                        : st.state === "building"
+                          ? "Importing the ISO + running the unattended install…"
+                          : "Not built yet."}
+                    </p>
+                    {st.state === "none" ? (
+                      <Button
+                        size="sm"
+                        onClick={() => build.mutate(os.value)}
+                        disabled={build.isPending}
+                      >
+                        <Plus className="size-4" /> Build
+                      </Button>
                     ) : (
-                      <Trash2 className="size-4" />
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => remove.mutate(os.value)}
+                        disabled={remove.isPending}
+                      >
+                        {st.state === "building" ? (
+                          <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="size-4" />
+                        )}
+                        {st.state === "building" ? "Cancel" : "Remove"}
+                      </Button>
                     )}
-                    {st.state === "building" ? "Cancel" : "Remove"}
-                  </Button>
-                )}
-              </CardContent>
-            </Card>
-          );
-        })}
-      </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+
+            {/* Live install screens for in-progress builds (under the panels). */}
+            {building.length ? (
+              <div className="mt-6 space-y-4">
+                <h3 className="text-sm font-medium">Live install</h3>
+                {building.map(({ os }) => (
+                  <div key={os.value} className="space-y-1">
+                    <div className="text-xs text-muted-foreground">
+                      {os.label} — watching <code>{os.value}-installer</code>
+                    </div>
+                    <InstallerVnc
+                      namespace={IMAGES_NAMESPACE}
+                      name={`${os.value}-installer`}
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </>
+        );
+      })()}
     </DetailShell>
   );
 }

--- a/ui/src/lib/k8s-paths.ts
+++ b/ui/src/lib/k8s-paths.ts
@@ -72,6 +72,10 @@ export const kubevirtPaths = {
   vmi: (ns: string, name: string) =>
     `${kvGV}/namespaces/${ns}/virtualmachineinstances/${name}`,
   vms: (ns?: string) => `${kvGV}${nsSegment(ns)}/virtualmachines`,
+  // VNC websocket subresource (served by virt-api). Relative to /api/k8s — the UI
+  // builds a same-origin wss URL that the BFF reverse-proxies (with the SA token).
+  vnc: (ns: string, name: string) =>
+    `/apis/subresources.kubevirt.io/v1/namespaces/${ns}/virtualmachineinstances/${name}/vnc`,
 };
 
 export const cnpgPaths = {

--- a/ui/src/types/novnc.d.ts
+++ b/ui/src/types/novnc.d.ts
@@ -1,0 +1,26 @@
+// Minimal type shim for noVNC's RFB client (the package ships no .d.ts).
+// Used by the VM Images live build console to watch installer VMs.
+declare module "@novnc/novnc" {
+  export interface RFBOptions {
+    shared?: boolean;
+    credentials?: { username?: string; password?: string; target?: string };
+    repeaterID?: string;
+    wsProtocols?: string[];
+  }
+  export default class RFB extends EventTarget {
+    constructor(
+      target: HTMLElement,
+      url: string | WebSocket,
+      options?: RFBOptions,
+    );
+    viewOnly: boolean;
+    scaleViewport: boolean;
+    resizeSession: boolean;
+    background: string;
+    qualityLevel: number;
+    compressionLevel: number;
+    disconnect(): void;
+    focus(): void;
+    blur(): void;
+  }
+}


### PR DESCRIPTION
Your ask: clicking **Build** on VM Images should show the install happening on screen, under the panels. Done.

## What
- **`InstallerVnc`** — a live, view-only noVNC view of the installer VM, rendered in a new **"Live install"** section under the version cards while a build runs.
- Connects to the KubeVirt VMI `/vnc` websocket through the BFF's same-origin `/api/k8s` proxy (the BFF injects the SA token — the browser never sees credentials).
- **Verified subprotocol:** I connected to the live Server 2019 installer's framebuffer and confirmed KubeVirt streams **raw RFB** (`RFB 003.008`) under **`plain.kubevirt.io`** (`binary` is rejected) — so noVNC uses `wsProtocols: ['plain.kubevirt.io']`.

## Scope
noVNC is re-added **only for watching image builds** — VM *access* stays native SSH/RDP (no web console for using VMs). RBAC grants the console SA exactly `subresources.kubevirt.io/virtualmachineinstances/vnc` (not console/exec).

## Validation
- `tsc` + production build green (noVNC bundles cleanly via its `exports` root).
- The VNC **path + subprotocol are empirically proven** against a real installer VM.
- The one piece exercised only post-deploy: the BFF reverse-proxying the *websocket* (Go's `ReverseProxy` tunnels upgrades + the k8s transport adds auth). If it needs a dedicated handler, that's a quick follow-up — but it should work as-is.

After merge + reload: VM Images → **Build** Server 2019 → the live screen appears under the cards and you watch Setup from frame one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)