### PR TITLE
build(babelfish): move base image to Ubuntu 24.04 LTS

### DIFF
--- a/babelfish/Dockerfile
+++ b/babelfish/Dockerfile
@@ -83,8 +83,10 @@ ENV BABELFISH_DATA=${POSTGRES_USER_HOME}/data
 EXPOSE 1433 5432
 
 # apt upgrade patches the fixable base-image CVEs; only runtime libs are installed.
+# adduser: no longer in the minimal ubuntu:24.04 base (it was in 22.04); the runtime
+# stage needs it for the `adduser postgres` step below.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-	libssl3 openssl libldap2 libxml2 libpam0g uuid libossp-uuid16 \
+	adduser libssl3 openssl libldap2 libxml2 libpam0g uuid libossp-uuid16 \
 	libxslt1.1 libicu74 libpq5 unixodbc \
 	&& apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/babelfish/Dockerfile
+++ b/babelfish/Dockerfile
@@ -7,7 +7,7 @@
 # patches — `apt upgrade` clears the fixable base-image CVEs the prebuilt image carried.
 #
 # Bump BABELFISH_VERSION deliberately (tags: github.com/babelfish-for-postgresql).
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 # ---------------------------------------------------------------------------- build
 FROM base AS builder
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
 	libxslt-dev libssl-dev libreadline-dev zlib1g-dev \
 	libldap2-dev libpam0g-dev gettext uuid uuid-dev \
 	cmake lld apt-utils libossp-uuid-dev gnulib bison \
-	xsltproc icu-devtools libicu70 \
+	xsltproc icu-devtools libicu74 \
 	libicu-dev gawk \
 	curl openjdk-21-jre openssl \
 	g++ python-dev-is-python3 libpq-dev \
@@ -84,8 +84,8 @@ EXPOSE 1433 5432
 
 # apt upgrade patches the fixable base-image CVEs; only runtime libs are installed.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
-	libssl3 openssl libldap-2.5-0 libxml2 libpam0g uuid libossp-uuid16 \
-	libxslt1.1 libicu70 libpq5 unixodbc \
+	libssl3 openssl libldap2 libxml2 libpam0g uuid libossp-uuid16 \
+	libxslt1.1 libicu74 libpq5 unixodbc \
 	&& apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN adduser postgres --home ${POSTGRES_USER_HOME}


### PR DESCRIPTION
Replaces the rejected Dependabot #99 (which bumped to the **EOL** Ubuntu 22.10) with the intended upgrade: **22.04 LTS → 24.04 LTS** (supported to 2029).

### Changes
- `FROM ubuntu:22.04` → `ubuntu:24.04`
- `libicu70` → `libicu74` (ICU 74 on Noble) — build + runtime stages
- `libldap-2.5-0` → `libldap2` (OpenLDAP 2.6 on Noble) — runtime stage

The build stage already used the version-agnostic `libldap2-dev`, so no change there. Runtime package names verified against the Ubuntu Noble archive.

### Validation
babelfish is built **from source** (ANTLR + the Babelfish PostgreSQL fork + extensions), so this needs the real compile to prove out — not a static check. I'll dispatch `build-babelfish` against this branch and report the result here before merging. `BABELFISH_VERSION` is unchanged (`BABEL_5_4_0__PG_17_7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)