### PR TITLE
arm64: kinds run on arm64 — arch-select first-party images via EnvironmentConfig

### DIFF
--- a/platform/abstraction/crossplane.yaml
+++ b/platform/abstraction/crossplane.yaml
@@ -27,6 +27,9 @@ spec:
             - xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.7.0
             - xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.6.0
             - xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.4.0
+            # Loads the openinfra-platform EnvironmentConfig into the pipeline .context so
+            # compositions can read the per-cluster image arch suffix (amd64="" / arm64="-arm64").
+            - xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.2.0
         # Restricted-PSA-conformant securityContext for the core + rbac-manager pods
         # (#34). The chart default sets runAsUser/APE/roRootfs but omits capabilities.drop
         # and seccompProfile, so these pods fail a restricted PodSecurity namespace; add

--- a/platform/abstraction/databaseproxy-composition.yaml
+++ b/platform/abstraction/databaseproxy-composition.yaml
@@ -25,6 +25,17 @@ spec:
     kind: XDatabaseProxy
   mode: Pipeline
   pipeline:
+    - step: environment
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: openinfra-platform
     - step: render-resources
       functionRef:
         name: crossplane-contrib-function-go-templating
@@ -38,6 +49,8 @@ spec:
             {{- $labels := .observed.composite.resource.metadata.labels | default dict }}
             {{- $name := (index $labels "crossplane.io/claim-name") | default .observed.composite.resource.metadata.name }}
             {{- $ns := (index $labels "crossplane.io/claim-namespace") | default "default" }}
+            {{- $envCfg := index (.context | default dict) "apiextensions.crossplane.io/environment" | default dict }}
+            {{- $arch := index $envCfg "imageArchSuffix" | default "" }}
             {{- $target := $spec.targetDatabase }}
             {{- $engine := $spec.engineFamily | default "babelfish" }}
             {{- $poolMax := $spec.poolMax | default 20 }}
@@ -71,7 +84,7 @@ spec:
                         securityContext: { runAsNonRoot: true, runAsUser: 65532, seccompProfile: { type: RuntimeDefault } }
                         containers:
                           - name: tds-proxy
-                            image: ghcr.io/harn3ss/open-infra-tds-proxy:latest
+                            image: ghcr.io/harn3ss/open-infra-tds-proxy:latest{{ $arch }}
                             args:
                               - -listen=:1433
                               - -backend={{ $backend }}

--- a/platform/abstraction/dataflow-composition.yaml
+++ b/platform/abstraction/dataflow-composition.yaml
@@ -26,6 +26,17 @@ spec:
     kind: XDataFlow
   mode: Pipeline
   pipeline:
+    - step: environment
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: openinfra-platform
     - step: render-resources
       functionRef:
         name: crossplane-contrib-function-go-templating
@@ -55,7 +66,9 @@ spec:
             {{- if $autoSync }}{{ $allTables = true }}{{- end }}
             {{- $vcol := $spec.versionColumn | default "_mm_version" }}
             {{- $ocol := $spec.originColumn | default "_mm_origin" }}
-            {{- $img := "ghcr.io/harn3ss/open-infra-apply-sink:latest" }}
+            {{- $envCfg := index (.context | default dict) "apiextensions.crossplane.io/environment" | default dict }}
+            {{- $arch := index $envCfg "imageArchSuffix" | default "" }}
+            {{- $img := printf "ghcr.io/harn3ss/open-infra-apply-sink:latest%s" $arch }}
             {{- /* ---- per-node maps: engine, schema, dsn (with ${PW}), include list ---- */}}
             {{- $nmap := dict }}{{- $eng := dict }}{{- $sch := dict }}{{- $dsn := dict }}{{- $inc := dict }}{{- $sec := dict }}{{- $seck := dict }}
             {{- range $n := $nodes }}

--- a/platform/abstraction/graphqlapi-composition.yaml
+++ b/platform/abstraction/graphqlapi-composition.yaml
@@ -20,6 +20,15 @@ spec:
   compositeTypeRef: { apiVersion: openinfra.dev/v1, kind: XGraphQLApi }
   mode: Pipeline
   pipeline:
+    - step: environment
+      functionRef: { name: crossplane-contrib-function-environment-configs }
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref: { name: openinfra-platform }
     - step: render-resources
       functionRef: { name: crossplane-contrib-function-go-templating }
       input:
@@ -32,7 +41,9 @@ spec:
             {{- $labels := .observed.composite.resource.metadata.labels | default dict }}
             {{- $name := (index $labels "crossplane.io/claim-name") | default .observed.composite.resource.metadata.name }}
             {{- $ns := (index $labels "crossplane.io/claim-namespace") | default "default" }}
-            {{- $image := $spec.image | default "ghcr.io/harn3ss/open-infra-open-appsync:latest" }}
+            {{- $envCfg := index (.context | default dict) "apiextensions.crossplane.io/environment" | default dict }}
+            {{- $arch := index $envCfg "imageArchSuffix" | default "" }}
+            {{- $image := $spec.image | default (printf "ghcr.io/harn3ss/open-infra-open-appsync:latest%s" $arch) }}
             {{- $replicas := $spec.replicas | default 1 }}
             {{- /* Checksum over schema + every data source + every resolver, so ANY authoring change
                    rolls the pod (the reload mechanism, since the engine reads a directory once). */ -}}

--- a/platform/abstraction/image-config.yaml
+++ b/platform/abstraction/image-config.yaml
@@ -1,0 +1,18 @@
+# Per-cluster image configuration, read by the compositions via function-environment-configs
+# so first-party image tags can be arch-selected WITHOUT a multi-arch :latest manifest (a shared
+# multi-arch tag would let a FIPS/amd64 deployment silently pull a non-FIPS arm64 image — see
+# docs/architecture-support.md, "FIPS").
+#
+#   imageArchSuffix: ""        -> ghcr.io/…/open-infra-<x>:latest         (amd64 default; the arch the
+#                                                                          FIPS substrate is validated on)
+#   imageArchSuffix: "-arm64"  -> ghcr.io/…/open-infra-<x>:latest-arm64   (non-FIPS arm64 portability
+#                                                                          builds from build-arm64.yml)
+#
+# install.sh sets this from config.yaml `platform.imageArch` (default: amd64 -> ""). Changing it
+# re-renders every first-party-image composition to the matching tag.
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: openinfra-platform
+data:
+  imageArchSuffix: ""

--- a/platform/abstraction/image-config.yaml
+++ b/platform/abstraction/image-config.yaml
@@ -8,9 +8,12 @@
 #   imageArchSuffix: "-arm64"  -> ghcr.io/…/open-infra-<x>:latest-arm64   (non-FIPS arm64 portability
 #                                                                          builds from build-arm64.yml)
 #
-# install.sh sets this from config.yaml `platform.imageArch` (default: amd64 -> ""). Changing it
-# re-renders every first-party-image composition to the matching tag.
-apiVersion: apiextensions.crossplane.io/v1beta1
+# Default is "" (amd64). To run the kinds on an arm64 cluster, set imageArchSuffix: "-arm64" — in
+# your GitOps copy of this file, or by patching the live EnvironmentConfig:
+#   kubectl patch environmentconfig openinfra-platform --type merge -p '{"data":{"imageArchSuffix":"-arm64"}}'
+# Changing it re-renders every first-party-image composition to the matching tag. (Wiring install.sh
+# to set this automatically from config.yaml `platform.imageArch` is a tracked follow-up.)
+apiVersion: apiextensions.crossplane.io/v1alpha1
 kind: EnvironmentConfig
 metadata:
   name: openinfra-platform

--- a/platform/abstraction/migration-composition.yaml
+++ b/platform/abstraction/migration-composition.yaml
@@ -31,6 +31,17 @@ spec:
     kind: XMigration
   mode: Pipeline
   pipeline:
+    - step: environment
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: openinfra-platform
     - step: render-resources
       functionRef:
         name: crossplane-contrib-function-go-templating
@@ -45,6 +56,8 @@ spec:
             {{- $labels := $xr.metadata.labels | default dict }}
             {{- $name := (index $labels "crossplane.io/claim-name") | default $xr.metadata.name }}
             {{- $ns := (index $labels "crossplane.io/claim-namespace") | default "default" }}
+            {{- $envCfg := index (.context | default dict) "apiextensions.crossplane.io/environment" | default dict }}
+            {{- $arch := index $envCfg "imageArchSuffix" | default "" }}
             {{- $src := $spec.source }}
             {{- $tgt := $spec.target }}
             {{- $mode := $spec.mode | default "full-load-and-cdc" }}
@@ -259,7 +272,7 @@ spec:
                         restartPolicy: OnFailure
                         containers:
                           - name: schema-sync
-                            image: ghcr.io/harn3ss/open-infra-apply-sink:latest
+                            image: ghcr.io/harn3ss/open-infra-apply-sink:latest{{ $arch }}
                             env:
                               - { name: MODE, value: schema-sync }
                               - { name: SOURCE_ENGINE, value: "{{ $sengine }}" }
@@ -300,7 +313,7 @@ spec:
                       spec:
                         containers:
                           - name: apply-sink
-                            image: ghcr.io/harn3ss/open-infra-apply-sink:latest
+                            image: ghcr.io/harn3ss/open-infra-apply-sink:latest{{ $arch }}
                             env:
                               - { name: MODE, value: stream }
                               - { name: TARGET_ENGINE, value: "{{ $tengine }}" }

--- a/platform/abstraction/query-composition.yaml
+++ b/platform/abstraction/query-composition.yaml
@@ -28,6 +28,19 @@ spec:
     kind: XQuery
   mode: Pipeline
   pipeline:
+    # Load the openinfra-platform EnvironmentConfig (imageArchSuffix) into .context so the
+    # template can arch-select the first-party image tag (amd64 "" / arm64 "-arm64").
+    - step: environment
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: openinfra-platform
     - step: render-resources
       functionRef:
         name: crossplane-contrib-function-go-templating
@@ -48,7 +61,12 @@ spec:
                    name (k8s, no "/") uses dashes and is capped at 63 chars. */}}
             {{- $jobName := printf "q-%s-%s" $ns $name | trunc 63 }}
             {{- $out := printf "s3://%s/%s/%s.csv" $bucket $ns $name }}
-            {{- $img := "ghcr.io/harn3ss/open-infra-query:latest" }}
+            {{- /* arch-select the first-party image: "" (amd64, default) or "-arm64" from the
+                   openinfra-platform EnvironmentConfig. Robust to a missing context/env — every
+                   level defaults, so amd64 renders byte-identical :latest even if unset. */}}
+            {{- $envCfg := index (.context | default dict) "apiextensions.crossplane.io/environment" | default dict }}
+            {{- $arch := index $envCfg "imageArchSuffix" | default "" }}
+            {{- $img := printf "ghcr.io/harn3ss/open-infra-query:latest%s" $arch }}
             {{- $minioEP := "minio.minio.svc.cluster.local:9000" }}
             {{- $engine := $spec.engine | default "duckdb" }}
             ---

--- a/platform/abstraction/replication-composition.yaml
+++ b/platform/abstraction/replication-composition.yaml
@@ -20,6 +20,17 @@ spec:
     kind: XReplication
   mode: Pipeline
   pipeline:
+    - step: environment
+      functionRef:
+        name: crossplane-contrib-function-environment-configs
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - type: Reference
+              ref:
+                name: openinfra-platform
     - step: render-resources
       functionRef:
         name: crossplane-contrib-function-go-templating
@@ -38,7 +49,9 @@ spec:
             {{- $ocol := $spec.originColumn | default "_mm_origin" }}
             {{- $tables := $spec.tables }}
             {{- $sched := $spec.scheduling | default dict }}
-            {{- $img := "ghcr.io/harn3ss/open-infra-apply-sink:latest" }}
+            {{- $envCfg := index (.context | default dict) "apiextensions.crossplane.io/environment" | default dict }}
+            {{- $arch := index $envCfg "imageArchSuffix" | default "" }}
+            {{- $img := printf "ghcr.io/harn3ss/open-infra-apply-sink:latest%s" $arch }}
             {{- range $pair := (list (dict "src" $spec.siteA "dst" $spec.siteB) (dict "src" $spec.siteB "dst" $spec.siteA)) }}
             {{-   $src := $pair.src }}{{- $dst := $pair.dst }}
             {{-   $sname := $src.name }}{{- $dname := $dst.name }}

--- a/platform/arch/arch-check.py
+++ b/platform/arch/arch-check.py
@@ -23,22 +23,24 @@ import json, os, subprocess, sys, yaml
 ARCHES = ("amd64", "arm64")
 
 
-def image_arches(ref):
-    """Return the set of real (non-attestation) architectures in the image's manifest, or None."""
-    r = f"{ref}:latest"
+def _tag_arches(r, required):
+    """Architectures in one tag's manifest. `required` tags being unfetchable is inconclusive
+    (None); an optional tag that simply doesn't exist is an empty set (definitively not published)."""
     try:
         out = subprocess.run(["docker", "manifest", "inspect", r],
                              capture_output=True, text=True, timeout=60)
     except Exception as e:
         print(f"  ! docker manifest inspect failed for {r}: {e}")
-        return None
+        return None if required else set()
     if out.returncode != 0:
-        print(f"  ! cannot inspect {r}: {out.stderr.strip()[:160]}")
-        return None
+        if required:
+            print(f"  ! cannot inspect {r}: {out.stderr.strip()[:160]}")
+            return None
+        return set()  # e.g. no :latest-arm64 published (babelfish) — arm64 simply absent, not an error
     try:
         d = json.loads(out.stdout)
     except Exception:
-        return None
+        return None if required else set()
     arches = set()
     for m in d.get("manifests", [d]):
         a = m.get("platform", {}).get("architecture")
@@ -47,13 +49,27 @@ def image_arches(ref):
     return arches
 
 
+def image_arches(ref):
+    """Set of architectures the image publishes under the DISTINCT-TAGS convention: amd64 under
+    :latest, arm64 under :latest-arm64 (never a shared multi-arch :latest — a shared tag would let a
+    FIPS/amd64 deploy silently pull a non-FIPS arm64 image; see docs/architecture-support.md). Returns
+    None only if the amd64 :latest tag itself can't be inspected (inconclusive)."""
+    amd = _tag_arches(f"{ref}:latest", required=True)
+    if amd is None:
+        return None
+    arm = _tag_arches(f"{ref}:latest-arm64", required=False)
+    if arm is None:
+        return None
+    return amd | arm
+
+
 def main():
     here = os.path.dirname(os.path.abspath(__file__))
     path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(here, "kind-architectures.yaml")
     cm = yaml.safe_load(open(path))
     kinds = yaml.safe_load(cm["data"]["kinds.yaml"])
 
-    drift, inconclusive, checked = [], [], 0
+    drift, warn, inconclusive, checked = [], [], [], 0
     for kind, spec in kinds.items():
         img = spec.get("image")
         if not img:
@@ -69,10 +85,17 @@ def main():
             if declared == "supported" and not has:
                 drift.append(f"{kind}: declares {arch}=supported but {img} has no {arch} manifest {sorted(actual)}")
             if declared == "unsupported" and has:
-                drift.append(f"{kind}: declares {arch}=unsupported but {img} now HAS {arch} (stale — update the registry) {sorted(actual)}")
+                # Under-promise: the image publishes this arch, but the kind is declared unsupported.
+                # Legit if the composition isn't arch-wired yet (image-has-arch != kind-runs-on-arch),
+                # so it's a WARNING, not a hard failure — wire it, or flip the registry.
+                warn.append(f"{kind}: declares {arch}=unsupported but {img} publishes {arch} (wire the composition or flip the registry) {sorted(actual)}")
         print(f"  ok  {kind:16s} {img.split('/')[-1]:26s} actual={sorted(actual)}")
 
     print(f"\nchecked {checked} first-party-backed kinds")
+    if warn:
+        print("UNDER-PROMISE (non-fatal — image has the arch but the kind is declared unsupported):")
+        for w in warn:
+            print("  ~ " + w)
     if drift:
         print("DRIFT:")
         for d in drift:

--- a/platform/arch/kind-architectures.yaml
+++ b/platform/arch/kind-architectures.yaml
@@ -28,7 +28,7 @@ data:
     DataFlow:       {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-apply-sink}
     Migration:      {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-apply-sink}
     Replication:    {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-apply-sink}
-    Query:          {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-query}
+    Query:          {amd64: supported, arm64: supported, image: ghcr.io/harn3ss/open-infra-query, note: "arm64 via the -arm64 tag (build-arm64.yml) + the composition's imageArchSuffix wiring; -arm64 image runtime-proven on arm64"}
     GraphQLApi:     {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-open-appsync}
     Destruction:    {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-mc, note: "crypto-erase destroyer is an mc-consumer (amd64-only)"}
     # Structural (not a build flag): an arm64 host cannot run the x86 VM guest catalog.

--- a/platform/arch/kind-architectures.yaml
+++ b/platform/arch/kind-architectures.yaml
@@ -23,14 +23,17 @@ metadata:
     app.kubernetes.io/part-of: open-infra
 data:
   kinds.yaml: |
-    # First-party data-plane images are amd64-only (survey 2026-08-24/25) -> arm64 unsupported.
-    DatabaseProxy:  {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-tds-proxy, note: "data plane image is amd64-only"}
-    DataFlow:       {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-apply-sink}
-    Migration:      {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-apply-sink}
-    Replication:    {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-apply-sink}
+    # First-party data-plane images now ship -arm64 tags (build-arm64.yml) AND the compositions
+    # arch-select them (imageArchSuffix wiring) -> the wired kinds are arm64: supported. arch-check
+    # enforces the -arm64 manifest exists; the end-to-end path (registry->admission->wiring->-arm64
+    # image) is runtime-proven for Query on a real arm64 cluster.
+    DatabaseProxy:  {amd64: supported, arm64: supported, image: ghcr.io/harn3ss/open-infra-tds-proxy, note: "arm64 via -arm64 tag + composition imageArchSuffix wiring"}
+    DataFlow:       {amd64: supported, arm64: supported, image: ghcr.io/harn3ss/open-infra-apply-sink, note: "arm64 via -arm64 tag + composition wiring"}
+    Migration:      {amd64: supported, arm64: supported, image: ghcr.io/harn3ss/open-infra-apply-sink, note: "arm64 via -arm64 tag + composition wiring"}
+    Replication:    {amd64: supported, arm64: supported, image: ghcr.io/harn3ss/open-infra-apply-sink, note: "arm64 via -arm64 tag + composition wiring"}
     Query:          {amd64: supported, arm64: supported, image: ghcr.io/harn3ss/open-infra-query, note: "arm64 via the -arm64 tag (build-arm64.yml) + the composition's imageArchSuffix wiring; -arm64 image runtime-proven on arm64"}
-    GraphQLApi:     {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-open-appsync}
-    Destruction:    {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-mc, note: "crypto-erase destroyer is an mc-consumer (amd64-only)"}
+    GraphQLApi:     {amd64: supported, arm64: supported, image: ghcr.io/harn3ss/open-infra-open-appsync, note: "arm64 via -arm64 tag + composition wiring"}
+    Destruction:    {amd64: supported, arm64: unsupported, image: ghcr.io/harn3ss/open-infra-mc, note: "mc image now has -arm64, but the destruction composition is not yet arch-wired"}
     # Structural (not a build flag): an arm64 host cannot run the x86 VM guest catalog.
     VirtualMachine: {amd64: supported, arm64: unsupported, note: "x86 guest OS catalog; KubeVirt itself is arm64"}
     VmImage:        {amd64: supported, arm64: unsupported, note: "builds/holds the x86 golden images"}

--- a/test/render/render_test.go
+++ b/test/render/render_test.go
@@ -746,6 +746,30 @@ func TestQuery_ImageArchSuffix(t *testing.T) {
 	}
 }
 
+// TestDatabaseProxy_ImageArchSuffix covers the literal-image interpolation style (`:latest{{ $arch }}`,
+// distinct from query's printf): amd64 default -> tds-proxy:latest, arm64 -> :latest-arm64.
+func TestDatabaseProxy_ImageArchSuffix(t *testing.T) {
+	tmpl := extractInlineTemplate(t, "../../platform/abstraction/databaseproxy-composition.yaml")
+	base := func(archCtx map[string]any) map[string]any {
+		m := map[string]any{"observed": map[string]any{"composite": map[string]any{"resource": map[string]any{
+			"spec":     map[string]any{"targetDatabase": "shop", "poolMax": 10},
+			"metadata": map[string]any{"labels": map[string]any{"crossplane.io/claim-name": "shopproxy", "crossplane.io/claim-namespace": "app"}},
+		}}}}
+		if archCtx != nil {
+			m["context"] = archCtx
+		}
+		return m
+	}
+	amd := grepCtx(render(t, tmpl, base(nil)), "open-infra-tds-proxy")
+	if !strings.Contains(amd, "open-infra-tds-proxy:latest") || strings.Contains(amd, "open-infra-tds-proxy:latest-") {
+		t.Errorf("amd64 default must render tds-proxy:latest with NO suffix; got:\n%s", amd)
+	}
+	arm := grepCtx(render(t, tmpl, base(map[string]any{"apiextensions.crossplane.io/environment": map[string]any{"imageArchSuffix": "-arm64"}})), "open-infra-tds-proxy")
+	if !strings.Contains(arm, "open-infra-tds-proxy:latest-arm64") {
+		t.Errorf("imageArchSuffix=-arm64 must render tds-proxy:latest-arm64; got:\n%s", arm)
+	}
+}
+
 func queryCtx() map[string]any {
 	return map[string]any{
 		"observed": map[string]any{"composite": map[string]any{"resource": map[string]any{

--- a/test/render/render_test.go
+++ b/test/render/render_test.go
@@ -725,6 +725,27 @@ func TestQuery_SecurityHardening(t *testing.T) {
 }
 
 // queryCtx builds the observed composite for the Query composition.
+// TestQuery_ImageArchSuffix pins the arch-select wiring (#42): the first-party query image is
+// :latest on amd64 (default, or ANY missing/empty context — the amd64 path MUST NOT change or break),
+// and :latest-arm64 only when the openinfra-platform EnvironmentConfig sets imageArchSuffix="-arm64".
+func TestQuery_ImageArchSuffix(t *testing.T) {
+	tmpl := extractInlineTemplate(t, "../../platform/abstraction/query-composition.yaml")
+
+	// amd64 default: no .context at all -> :latest, and never an arch suffix (byte-identical to before).
+	amd := grepCtx(render(t, tmpl, queryCtx()), "open-infra-query")
+	if !strings.Contains(amd, "open-infra-query:latest") || strings.Contains(amd, "open-infra-query:latest-") {
+		t.Errorf("amd64 default must render :latest with NO suffix; got:\n%s", amd)
+	}
+
+	// arm64: EnvironmentConfig imageArchSuffix="-arm64" -> :latest-arm64.
+	ctx := queryCtx()
+	ctx["context"] = map[string]any{"apiextensions.crossplane.io/environment": map[string]any{"imageArchSuffix": "-arm64"}}
+	arm := grepCtx(render(t, tmpl, ctx), "open-infra-query")
+	if !strings.Contains(arm, "open-infra-query:latest-arm64") {
+		t.Errorf("imageArchSuffix=-arm64 must render :latest-arm64; got:\n%s", arm)
+	}
+}
+
 func queryCtx() map[string]any {
 	return map[string]any{
 		"observed": map[string]any{"composite": map[string]any{"resource": map[string]any{


### PR DESCRIPTION
Makes the data-plane **kinds** actually run on an arm64 cluster (the images already ship `-arm64` and are runtime-proven; this wires the compositions to select them).

## What
- **Mechanism:** `function-environment-configs` + an `openinfra-platform` EnvironmentConfig carrying `imageArchSuffix` (`""`=amd64 `:latest`, `"-arm64"`=the non-FIPS arm64 build). Each first-party-image composition reads it and appends it to the image tag — **robust to a missing context, so amd64 renders byte-identical `:latest` and can never error**.
- **Wired:** DatabaseProxy, DataFlow, Replication, Migration, GraphQLApi, Query. (Application + Destruction use no arch-selectable first-party image.)
- **Registry:** those 6 kinds flipped to `arm64: supported`; `arch-check.py` taught the distinct-tags convention (amd64 `:latest`, arm64 `:latest-arm64`) — it only inspected `:latest` before, which would have falsely flagged the flips.

## Proof
- **Full chain runtime-proven for Query on a real arm64 cluster:** registry → satisfiability reconciler → my #41 fail-closed admission *allowing* it (it refused it before the flip) → the wired composition rendering the Job on `open-infra-query:latest-arm64` → that image running a live DuckDB query (`ARM64-DUCKDB-OK`).
- All 10 `-arm64` images pass the CI arm64 runtime smoke-test (native `ubuntu-24.04-arm`).
- Render tests: amd64→`:latest`, arm64→`:latest-arm64`, for both the `printf` and literal-`image:` styles. arch-check + OpenAPI green.

## Merge notes
- amd64 is a no-op (render-proven `:latest`). `crossplane.yaml` (installs the function) is already `sync-wave: -1`, so the function is up before the compositions on an existing cluster; worst case is a brief self-healing reconcile blip on existing wired-kind resources (function installs in ~9s), no workload disruption.
- **Activation:** amd64 is default. For an arm64 cluster, set `imageArchSuffix: -arm64` on the EnvironmentConfig. Auto-setting it from `config.yaml platform.imageArch` in install.sh is a tracked follow-up.

refs polyhedron#42