### PR TITLE
Phase 2 spike: Cedar control-plane authorization webhook (design + offline)

### DIFF
--- a/console-api/cmd/authz-webhook/main.go
+++ b/console-api/cmd/authz-webhook/main.go
@@ -1,0 +1,68 @@
+// authz-webhook is a spike of the open-infra control-plane authorization webhook: it implements the
+// Kubernetes authorization-webhook contract (a SubjectAccessReview in, an allow/deny/no-opinion out)
+// and decides via the Cedar policy engine over kind: Policy spec.controlPlane. See
+// docs/authz-webhook.md.
+//
+// SPIKE — NOT wired to any live API server. It defaults to SHADOW mode: it computes and logs the
+// Cedar decision but always returns "no opinion", so a real chain still decides with RBAC. This is
+// how divergence is measured before anything is enforced. AUTHZ_MODE=enforce returns the Cedar
+// decision (default-deny) — only for a cluster whose implicit principals already have explicit
+// grants. Serving TLS with the FIPS-validated modules is a deployment concern (the webhook is a
+// control-plane network service); this spike serves plain HTTP for offline testing.
+package main
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/harn3ss/open-infra/console-api/internal/controlplaneauthz"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	mode := Shadow
+	if os.Getenv("AUTHZ_MODE") == "enforce" {
+		mode = Enforce
+	}
+
+	cfg, err := restConfig()
+	if err != nil {
+		logger.Error("cannot build a kube client config", "err", err)
+		os.Exit(1)
+	}
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		logger.Error("cannot build a dynamic client", "err", err)
+		os.Exit(1)
+	}
+	checker := controlplaneauthz.New(controlplaneauthz.K8sLoader(dyn), 30*time.Second)
+	h := &webhookHandler{checker: checker, mode: mode, logger: logger}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/authorize", h.serve)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("ok")) })
+
+	addr := os.Getenv("LISTEN_ADDR")
+	if addr == "" {
+		addr = ":8443"
+	}
+	logger.Info("control-plane authz webhook (SPIKE — not wired to any API server)", "mode", mode, "addr", addr)
+	srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+	if err := srv.ListenAndServe(); err != nil {
+		logger.Error("server exited", "err", err)
+		os.Exit(1)
+	}
+}
+
+func restConfig() (*rest.Config, error) {
+	if kc := os.Getenv("KUBECONFIG"); kc != "" {
+		return clientcmd.BuildConfigFromFlags("", kc)
+	}
+	return rest.InClusterConfig()
+}

--- a/console-api/cmd/authz-webhook/webhook.go
+++ b/console-api/cmd/authz-webhook/webhook.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/harn3ss/open-infra/console-api/internal/controlplaneauthz"
+	"github.com/harn3ss/open-infra/policyengine"
+	authzv1 "k8s.io/api/authorization/v1"
+)
+
+// Mode selects how a Cedar decision is turned into a SubjectAccessReview answer.
+type Mode string
+
+const (
+	// Shadow always returns "no opinion" so the next authorizer (RBAC) still decides; the Cedar
+	// decision is only logged, to measure divergence before anything is enforced.
+	Shadow Mode = "shadow"
+	// Enforce returns the Cedar decision as the authoritative answer (allow or explicit deny).
+	Enforce Mode = "enforce"
+)
+
+// answer builds the SubjectAccessReviewStatus the API server reads. Shadow never expresses an
+// opinion (allowed=false, denied=false → defer); enforce returns allow, or an explicit deny.
+func answer(d policyengine.Decision, mode Mode) authzv1.SubjectAccessReviewStatus {
+	if mode == Enforce {
+		if d.Allowed {
+			return authzv1.SubjectAccessReviewStatus{Allowed: true, Reason: d.Reason}
+		}
+		return authzv1.SubjectAccessReviewStatus{Allowed: false, Denied: true, Reason: d.Reason}
+	}
+	return authzv1.SubjectAccessReviewStatus{Allowed: false, Denied: false, Reason: "shadow (no opinion): would be " + verdict(d) + " — " + d.Reason}
+}
+
+func verdict(d policyengine.Decision) string {
+	if d.Allowed {
+		return "ALLOW"
+	}
+	return "DENY"
+}
+
+// webhookHandler serves the Kubernetes authorization-webhook contract: a SubjectAccessReview in, the
+// same object with its Status filled, out.
+type webhookHandler struct {
+	checker *controlplaneauthz.Checker
+	mode    Mode
+	logger  *slog.Logger
+}
+
+func (h *webhookHandler) serve(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	var sar authzv1.SubjectAccessReview
+	if err := json.NewDecoder(r.Body).Decode(&sar); err != nil {
+		http.Error(w, "invalid SubjectAccessReview: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	d := h.checker.Evaluate(r.Context(), sar.Spec)
+	// Log every decision — the whole point of shadow mode is the divergence record.
+	h.logger.Info("control-plane authz decision",
+		"mode", h.mode, "user", sar.Spec.User, "verb", verbOf(sar.Spec),
+		"resource", resourceOf(sar.Spec), "wouldAllow", d.Allowed, "reason", d.Reason)
+	sar.Status = answer(d, h.mode)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(&sar)
+}
+
+func verbOf(s authzv1.SubjectAccessReviewSpec) string {
+	if s.ResourceAttributes != nil {
+		return s.ResourceAttributes.Verb
+	}
+	if s.NonResourceAttributes != nil {
+		return s.NonResourceAttributes.Verb
+	}
+	return ""
+}
+
+func resourceOf(s authzv1.SubjectAccessReviewSpec) string {
+	if ra := s.ResourceAttributes; ra != nil {
+		r := ra.Resource
+		if ra.Group != "" {
+			r += "." + ra.Group
+		}
+		if ra.Namespace != "" {
+			r += " (" + ra.Namespace + "/" + ra.Name + ")"
+		} else if ra.Name != "" {
+			r += " (" + ra.Name + ")"
+		}
+		return r
+	}
+	if nra := s.NonResourceAttributes; nra != nil {
+		return nra.Path
+	}
+	return ""
+}

--- a/console-api/cmd/authz-webhook/webhook_test.go
+++ b/console-api/cmd/authz-webhook/webhook_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/harn3ss/open-infra/console-api/internal/controlplaneauthz"
+	"github.com/harn3ss/open-infra/policyengine"
+	authzv1 "k8s.io/api/authorization/v1"
+)
+
+func checkerFor(appliesTo []string, stmts ...policyengine.Statement) *controlplaneauthz.Checker {
+	return controlplaneauthz.New(func(context.Context) ([]controlplaneauthz.PolicyDoc, error) {
+		return []controlplaneauthz.PolicyDoc{{AppliesTo: appliesTo, Statements: stmts}}, nil
+	}, time.Minute)
+}
+
+func discard() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// sar builds a SubjectAccessReview the API server would POST.
+func sar(user string, groups []string, verb, group, resource, ns, name string) *authzv1.SubjectAccessReview {
+	return &authzv1.SubjectAccessReview{
+		Spec: authzv1.SubjectAccessReviewSpec{
+			User: user, Groups: groups,
+			ResourceAttributes: &authzv1.ResourceAttributes{Verb: verb, Group: group, Resource: resource, Namespace: ns, Name: name},
+		},
+	}
+}
+
+func post(t *testing.T, h *webhookHandler, review *authzv1.SubjectAccessReview) authzv1.SubjectAccessReviewStatus {
+	t.Helper()
+	body, _ := json.Marshal(review)
+	req := httptest.NewRequest("POST", "/authorize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.serve(w, req)
+	if w.Code != 200 {
+		t.Fatalf("status %d: %s", w.Code, w.Body.String())
+	}
+	var out authzv1.SubjectAccessReview
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out.Status
+}
+
+// Shadow mode NEVER expresses an opinion — it always defers (allowed=false, denied=false) so RBAC
+// still decides — regardless of what Cedar would have said.
+func TestWebhook_ShadowAlwaysDefers(t *testing.T) {
+	h := &webhookHandler{
+		checker: checkerFor([]string{"Group::admins"},
+			policyengine.Statement{Effect: policyengine.Allow, Actions: []string{"*"}, Resources: []string{"*"}}),
+		mode: Shadow, logger: discard(),
+	}
+	// Even a request Cedar would ALLOW is deferred in shadow.
+	st := post(t, h, sar("alice", []string{"admins"}, "delete", "openinfra.dev", "databases", "prod", "db1"))
+	if st.Allowed || st.Denied {
+		t.Fatalf("shadow must express no opinion, got allowed=%v denied=%v", st.Allowed, st.Denied)
+	}
+	// And a request Cedar would DENY is also deferred (never an enforced deny in shadow).
+	st = post(t, h, sar("nobody", []string{"interns"}, "get", "", "secrets", "kube-system", "root"))
+	if st.Allowed || st.Denied {
+		t.Fatalf("shadow must not deny, got allowed=%v denied=%v", st.Allowed, st.Denied)
+	}
+}
+
+// Enforce mode returns the real Cedar decision: an allow, and an explicit deny for the ungranted.
+func TestWebhook_EnforceReturnsDecision(t *testing.T) {
+	h := &webhookHandler{
+		checker: checkerFor([]string{"Group::admins"},
+			policyengine.Statement{Effect: policyengine.Allow, Actions: []string{"get", "list"}, Resources: []string{"applications.openinfra.dev::*"}}),
+		mode: Enforce, logger: discard(),
+	}
+	if st := post(t, h, sar("alice", []string{"admins"}, "get", "openinfra.dev", "applications", "team-a", "app")); !st.Allowed {
+		t.Fatalf("enforce should allow a granted get, got %+v", st)
+	}
+	// An ungranted verb → explicit deny (default-deny allow-list).
+	st := post(t, h, sar("alice", []string{"admins"}, "delete", "openinfra.dev", "applications", "team-a", "app"))
+	if st.Allowed || !st.Denied {
+		t.Fatalf("enforce should explicitly deny an ungranted verb, got allowed=%v denied=%v", st.Allowed, st.Denied)
+	}
+}

--- a/console-api/internal/controlplaneauthz/authz.go
+++ b/console-api/internal/controlplaneauthz/authz.go
@@ -1,0 +1,148 @@
+// Package controlplaneauthz evaluates Kubernetes SubjectAccessReview requests against the Cedar
+// policy engine, using kind: Policy spec.controlPlane statements. It is the core of the
+// authorization-webhook spike (see docs/authz-webhook.md): the SAME evaluator as the data plane,
+// over a control-plane vocabulary (a k8s verb -> Cedar action, resource.group -> resource type,
+// namespace/name -> resource id). Governance here is REPLACEMENT semantics — default-deny
+// allow-list, Cedar as the sole authority — not the data plane's additive, per-service tightening.
+// The Checker only computes the decision; the webhook handler decides how to answer the API server
+// (shadow: log and defer; enforce: return the decision).
+package controlplaneauthz
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/harn3ss/open-infra/policyengine"
+	authzv1 "k8s.io/api/authorization/v1"
+)
+
+// PolicyDoc is one kind: Policy's control-plane block.
+type PolicyDoc struct {
+	Statements []policyengine.Statement
+	AppliesTo  []string // "User::alice", "Group::eng", "ServiceAccount::ns/name", or "*"
+}
+
+// Loader returns the current control-plane policy docs.
+type Loader func(context.Context) ([]PolicyDoc, error)
+
+// Checker resolves + evaluates control-plane policies for a SubjectAccessReview, caching the corpus.
+type Checker struct {
+	load    Loader
+	ttl     time.Duration
+	mu      sync.Mutex
+	cache   []PolicyDoc
+	err     error
+	fetched time.Time
+	seeded  bool
+}
+
+// New builds a Checker. A nil loader disables it (Evaluate denies with a clear reason).
+func New(load Loader, ttl time.Duration) *Checker { return &Checker{load: load, ttl: ttl} }
+
+// Evaluate returns the Cedar decision for a SubjectAccessReview under default-deny allow-list
+// semantics: a principal with no matching statement is denied. It fails closed on a load/compile
+// error. It does not decide chain placement — the webhook wraps this per mode.
+func (c *Checker) Evaluate(ctx context.Context, spec authzv1.SubjectAccessReviewSpec) policyengine.Decision {
+	if c == nil || c.load == nil {
+		return policyengine.Decision{Allowed: false, Reason: "control-plane authz disabled"}
+	}
+	docs, err := c.get(ctx)
+	if err != nil {
+		return policyengine.Decision{Allowed: false, Reason: "control-plane policy load failed: " + err.Error()}
+	}
+	var stmts []policyengine.Statement
+	for _, d := range docs {
+		if principalMatches(d.AppliesTo, spec) {
+			stmts = append(stmts, d.Statements...)
+		}
+	}
+	if len(stmts) == 0 {
+		return policyengine.Decision{Allowed: false, Reason: "no control-plane policy grants this principal (default deny)"}
+	}
+	eng, err := policyengine.NewEngine(stmts)
+	if err != nil {
+		return policyengine.Decision{Allowed: false, Reason: "control-plane policy compile error: " + err.Error()}
+	}
+	return eng.Authorize(toRequest(spec))
+}
+
+// toRequest maps a SubjectAccessReview onto a policyengine.Request: the k8s verb is the action, the
+// resource is "<resource>.<group>" (id "<namespace>/<name>"), and a non-resource URL is its path.
+func toRequest(spec authzv1.SubjectAccessReviewSpec) policyengine.Request {
+	principal := policyengine.Principal{Type: "User", ID: spec.User}
+	if ra := spec.ResourceAttributes; ra != nil {
+		rtype := ra.Resource
+		if ra.Group != "" {
+			rtype = ra.Resource + "." + ra.Group
+		}
+		id := ra.Name
+		if ra.Namespace != "" {
+			id = ra.Namespace + "/" + ra.Name
+		}
+		// Named to NOT collide with the engine's reserved "action"/"resource" context keys — these
+		// are here only for future control-plane conditions (e.g. deny in the kube-system namespace).
+		ctx := map[string]any{
+			"namespace": ra.Namespace, "subresource": ra.Subresource,
+			"apiGroup": ra.Group, "apiResource": ra.Resource,
+		}
+		return policyengine.Request{Principal: principal, Action: ra.Verb,
+			Resource: policyengine.Resource{Type: rtype, ID: id}, Context: ctx}
+	}
+	if nra := spec.NonResourceAttributes; nra != nil {
+		return policyengine.Request{Principal: principal, Action: nra.Verb,
+			Resource: policyengine.Resource{Type: "NonResourceURL", ID: nra.Path}, Context: map[string]any{}}
+	}
+	return policyengine.Request{Principal: principal, Context: map[string]any{}}
+}
+
+// principalMatches reports whether a policy's appliesTo names the SAR's user, one of its groups, or
+// (for a ServiceAccount principal) the "system:serviceaccount:<ns>:<name>" user the API server sends.
+func principalMatches(list []string, spec authzv1.SubjectAccessReviewSpec) bool {
+	for _, e := range list {
+		if e == "*" {
+			return true
+		}
+		t, val, ok := strings.Cut(e, "::")
+		if !ok {
+			continue
+		}
+		switch t {
+		case "User":
+			if val == spec.User {
+				return true
+			}
+		case "ServiceAccount":
+			if ns, name, ok := strings.Cut(val, "/"); ok && spec.User == "system:serviceaccount:"+ns+":"+name {
+				return true
+			}
+		case "Group":
+			want := strings.TrimPrefix(val, "openinfra:")
+			for _, g := range spec.Groups {
+				if strings.TrimPrefix(g, "openinfra:") == want {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// get caches the corpus and serves the last-good snapshot through a refresh blip (a control-plane
+// read stall degrades to stale policy, never to deny-everything) — the same hardening the
+// data-plane loader has. Cold start with no corpus fails closed.
+func (c *Checker) get(ctx context.Context) ([]PolicyDoc, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.seeded && time.Since(c.fetched) < c.ttl {
+		return c.cache, c.err
+	}
+	docs, err := c.load(ctx)
+	if err != nil && c.seeded {
+		c.fetched = time.Now()
+		return c.cache, c.err
+	}
+	c.cache, c.err, c.fetched, c.seeded = docs, err, time.Now(), true
+	return docs, err
+}

--- a/console-api/internal/controlplaneauthz/authz_test.go
+++ b/console-api/internal/controlplaneauthz/authz_test.go
@@ -1,0 +1,107 @@
+package controlplaneauthz
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/harn3ss/open-infra/policyengine"
+	authzv1 "k8s.io/api/authorization/v1"
+)
+
+func fixed(docs []PolicyDoc, err error) Loader {
+	return func(context.Context) ([]PolicyDoc, error) { return docs, err }
+}
+
+func resReq(user string, groups []string, verb, group, resource, ns, name string) authzv1.SubjectAccessReviewSpec {
+	return authzv1.SubjectAccessReviewSpec{
+		User:   user,
+		Groups: groups,
+		ResourceAttributes: &authzv1.ResourceAttributes{
+			Verb: verb, Group: group, Resource: resource, Namespace: ns, Name: name,
+		},
+	}
+}
+
+// A group grant allows its verbs on a resource type; an explicit Deny overrides (which RBAC cannot
+// express); a principal no statement names is default-denied.
+func TestEvaluate_GroupGrantWithForbid(t *testing.T) {
+	docs := []PolicyDoc{{
+		AppliesTo: []string{"Group::platform-admins"},
+		Statements: []policyengine.Statement{
+			{Effect: policyengine.Allow, Actions: []string{"get", "list", "create", "update", "delete"},
+				Resources: []string{"databases.openinfra.dev::*"}},
+			{Effect: policyengine.Deny, Actions: []string{"delete"},
+				Resources: []string{"databases.openinfra.dev::prod/*"}},
+		},
+	}}
+	c := New(fixed(docs, nil), time.Minute)
+	ctx := context.Background()
+	admins := []string{"openinfra:platform-admins"}
+
+	if d := c.Evaluate(ctx, resReq("alice", admins, "create", "openinfra.dev", "databases", "team-a", "db1")); !d.Allowed {
+		t.Errorf("create db in team-a should be allowed: %s", d.Reason)
+	}
+	if d := c.Evaluate(ctx, resReq("alice", admins, "delete", "openinfra.dev", "databases", "prod", "db1")); d.Allowed {
+		t.Errorf("delete of a prod db must be denied by the forbid, got allowed")
+	}
+	// A verb the grant does not include → default deny within the allow-list.
+	if d := c.Evaluate(ctx, resReq("alice", admins, "escalate", "openinfra.dev", "databases", "team-a", "db1")); d.Allowed {
+		t.Errorf("an ungranted verb must be denied, got allowed")
+	}
+	// A principal no statement names → default deny (Cedar is the sole authority here).
+	if d := c.Evaluate(ctx, resReq("mallory", []string{"openinfra:interns"}, "get", "openinfra.dev", "databases", "team-a", "db1")); d.Allowed {
+		t.Errorf("an ungoverned principal must be denied under replacement semantics, got allowed")
+	}
+}
+
+// A ServiceAccount principal is matched from the API server's "system:serviceaccount:ns:name" user.
+func TestEvaluate_ServiceAccountPrincipal(t *testing.T) {
+	docs := []PolicyDoc{{
+		AppliesTo:  []string{"ServiceAccount::open-infra-console/console-api"},
+		Statements: []policyengine.Statement{{Effect: policyengine.Allow, Actions: []string{"*"}, Resources: []string{"*"}}},
+	}}
+	c := New(fixed(docs, nil), time.Minute)
+	spec := resReq("system:serviceaccount:open-infra-console:console-api", nil, "list", "openinfra.dev", "applications", "team-a", "")
+	if d := c.Evaluate(context.Background(), spec); !d.Allowed {
+		t.Errorf("the console-api SA should be granted: %s", d.Reason)
+	}
+	// A different SA is not matched.
+	other := resReq("system:serviceaccount:other:sa", nil, "list", "openinfra.dev", "applications", "team-a", "")
+	if d := c.Evaluate(context.Background(), other); d.Allowed {
+		t.Errorf("a different SA must not inherit the grant, got allowed")
+	}
+}
+
+// A non-resource URL (health, metrics) maps to resource type NonResourceURL by path.
+func TestEvaluate_NonResourceURL(t *testing.T) {
+	docs := []PolicyDoc{{
+		AppliesTo:  []string{"Group::system:monitoring"},
+		Statements: []policyengine.Statement{{Effect: policyengine.Allow, Actions: []string{"get"}, Resources: []string{"NonResourceURL::/metrics"}}},
+	}}
+	c := New(fixed(docs, nil), time.Minute)
+	spec := authzv1.SubjectAccessReviewSpec{
+		User: "prometheus", Groups: []string{"system:monitoring"},
+		NonResourceAttributes: &authzv1.NonResourceAttributes{Verb: "get", Path: "/metrics"},
+	}
+	if d := c.Evaluate(context.Background(), spec); !d.Allowed {
+		t.Errorf("GET /metrics should be allowed: %s", d.Reason)
+	}
+	spec.NonResourceAttributes.Path = "/healthz"
+	if d := c.Evaluate(context.Background(), spec); d.Allowed {
+		t.Errorf("GET /healthz is not granted, must be denied, got allowed")
+	}
+}
+
+// Fail-closed: a cold-start load error denies; a nil checker denies with a clear reason.
+func TestEvaluate_FailClosed(t *testing.T) {
+	c := New(fixed(nil, errors.New("apiserver down")), time.Minute)
+	if d := c.Evaluate(context.Background(), resReq("alice", nil, "get", "", "pods", "default", "x")); d.Allowed {
+		t.Errorf("a load error must fail closed, got allowed")
+	}
+	var nilc *Checker
+	if d := nilc.Evaluate(context.Background(), resReq("alice", nil, "get", "", "pods", "default", "x")); d.Allowed {
+		t.Errorf("a nil checker must deny, got allowed")
+	}
+}

--- a/console-api/internal/controlplaneauthz/k8sloader.go
+++ b/console-api/internal/controlplaneauthz/k8sloader.go
@@ -1,0 +1,77 @@
+package controlplaneauthz
+
+import (
+	"context"
+
+	"github.com/harn3ss/open-infra/policyengine"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var policyGVR = schema.GroupVersionResource{Group: "iam.openinfra.dev", Version: "v1", Resource: "policies"}
+
+// K8sLoader lists every kind: Policy in the cluster and extracts its spec.controlPlane block. A
+// policy with no controlPlane block is ignored. (The spec.controlPlane XRD field is not yet defined;
+// the loader reads it if present — the spike works against fixtures until the field lands.)
+func K8sLoader(dc dynamic.Interface) Loader {
+	return func(ctx context.Context) ([]PolicyDoc, error) {
+		list, err := dc.Resource(policyGVR).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		var docs []PolicyDoc
+		for i := range list.Items {
+			spec, _ := list.Items[i].Object["spec"].(map[string]any)
+			cp, _ := spec["controlPlane"].(map[string]any)
+			if cp == nil {
+				continue
+			}
+			doc := PolicyDoc{AppliesTo: toStrings(cp["appliesTo"])}
+			for _, s := range toSlice(cp["statements"]) {
+				sm, _ := s.(map[string]any)
+				if sm == nil {
+					continue
+				}
+				doc.Statements = append(doc.Statements, policyengine.Statement{
+					Effect:    policyengine.Effect(str(sm["effect"])),
+					Actions:   toStrings(sm["actions"]),
+					Resources: toStrings(sm["resources"]),
+					Condition: toStringMap(sm["condition"]),
+				})
+			}
+			if len(doc.Statements) > 0 {
+				docs = append(docs, doc)
+			}
+		}
+		return docs, nil
+	}
+}
+
+func toSlice(v any) []any { s, _ := v.([]any); return s }
+func str(v any) string    { s, _ := v.(string); return s }
+
+func toStrings(v any) []string {
+	items, _ := v.([]any)
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func toStringMap(v any) map[string]string {
+	m, _ := v.(map[string]any)
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, val := range m {
+		if s, ok := val.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}

--- a/docs/authz-webhook.md
+++ b/docs/authz-webhook.md
@@ -1,0 +1,135 @@
+# Control-plane authorization webhook (design + spike, WIP)
+
+> Status: **design + offline spike** on `feat/authz-webhook`. Nothing here is wired to any live
+> API server. This is Phase 2 of making Cedar the platform-wide authorization authority
+> ([`docs/policy-engine.md`](policy-engine.md)): the data plane (Phase 1) is built and
+> live-verified; this extends the *same* engine and the *same* `kind: Policy` corpus to the
+> Kubernetes control plane, through the API server's authorization-webhook interface.
+
+## The interface (why a webhook, not admission)
+
+Kubernetes lets the API server delegate an authorization decision to an external webhook: for a
+request it cannot itself allow, or for every request when the webhook is first in the chain, it
+POSTs a `SubjectAccessReview` (`authorization.k8s.io/v1`) — the principal (`user`, `groups`,
+`extra`), and either `resourceAttributes` (verb, group, resource, subresource, namespace, name) or
+`nonResourceAttributes` (path, verb) — and reads back `{allowed, denied, reason}`.
+
+This is the **authorization** webhook, not an admission webhook, and the distinction is the whole
+reason it can be the authority: admission fires only on writes, so it can never govern
+get/list/watch; the authorization webhook is consulted for **every verb, reads included**. It sees
+the same request shape RBAC sees, so a Cedar decision can be a true drop-in for an RBAC decision.
+
+## One policy world
+
+Control-plane statements ride the existing `kind: Policy`, in a `spec.controlPlane` block alongside
+`spec.dataPlane` — never a parallel authz world. A statement is the same shape the data-plane engine
+already compiles to Cedar, with a control-plane vocabulary:
+
+```yaml
+spec:
+  controlPlane:
+    appliesTo: ["Group::platform-admins", "ServiceAccount::open-infra-console/console-api"]
+    statements:
+      - { effect: Allow, actions: ["get","list","watch","create","update","delete"],
+          resources: ["databases.openinfra.dev::*"] }
+      - { effect: Deny,  actions: ["delete"], resources: ["databases.openinfra.dev::prod/*"] }
+```
+
+The `SubjectAccessReview` maps onto a `policyengine.Request` with no new evaluator:
+
+| SAR field | Cedar |
+|---|---|
+| `user` + `groups` | principal + the groups a statement's `appliesTo` may name |
+| `verb` (`get`, `create`, …) | **action** |
+| `resource` + `group` | resource **type** — `databases.openinfra.dev` |
+| `namespace`/`name` | resource **id** — `<namespace>/<name>` (also in context) |
+| `subresource`, `apiGroup`, `apiVersion` | request **context** |
+| `nonResourceAttributes` (`/healthz`) | resource type `NonResourceURL`, id = path |
+
+So the engine's existing allow/deny/condition semantics — explicit `forbid` overriding, default-deny
+— carry straight over. That is the point of Phase 1 first: the evaluator is already proven.
+
+## Shadow first — measure divergence before deciding anything
+
+RBAC must not leave the chain until Cedar's answer has been compared to RBAC's on **real** traffic
+and every disagreement is understood. The webhook therefore ships in a **shadow** mode:
+
+- Placed **first** in the authorization chain with `failurePolicy: NoOpinion`, it computes the Cedar
+  decision for every request, **logs** `{request, cedarDecision, principal}`, and returns
+  *no opinion* (`allowed:false, denied:false`) — so the real decision is still RBAC's, downstream.
+- Divergence is then a log-join: where Cedar would `Deny` a request the audit log shows RBAC
+  allowed (or vice-versa), that case is recorded and explained — **not tuned away**.
+- Because it returns no-opinion and fails open to the next authorizer, a shadow webhook that is slow
+  or down cannot break the cluster. This is the safe way to gather the evidence Phase 2 step 2 wants.
+
+Only after the divergence set is empty-or-explained, and with explicit approval, does the webhook
+switch to **enforce** mode (return the real decision) and RBAC leave the chain.
+
+## The bootstrap problem
+
+The authorizer must not need authorization from itself to start. Two rules make the startup
+acyclic:
+
+1. **A static allow ahead of the webhook** for the identities that must always pass: the
+   `system:masters` break-glass group, the API server's own identity, and the webhook's own
+   ServiceAccount (so it can read its policy corpus). These are expressed in the API server's
+   authorization config *before* the webhook entry, not inside Cedar, so a broken or empty corpus
+   can never lock everyone out.
+2. **The corpus loads over a path the webhook does not gate.** The webhook reads `kind: Policy` via
+   the API server; during the shadow/transition phase RBAC still authorizes that read, and in the
+   end state the static allow for its own SA does. It serves last-known policy if the read blips
+   (the same hardening the data-plane loader already has), so a control-plane read stall degrades to
+   stale policy, never to "deny everything."
+
+## Failure and availability posture
+
+The authorizer sits in the **control-plane path**: its latency is the API server's latency and its
+availability is a cluster-wide dependency. Stated decisions, to be evidenced before enforce mode:
+
+- **Fail-closed by construction, with a hard floor.** In enforce mode a webhook error is a deny —
+  except the static-allow floor above, which is evaluated by the API server, not the webhook, so an
+  admin with `system:masters` can always recover a cluster whose authorizer is wedged. This is the
+  emergency bypass, and it is deliberate.
+- **HA.** Multiple replicas behind a Service; the API server retries; a rollout never has zero
+  ready endpoints. It runs in-cluster but its manifest pins it away from the very workloads it
+  gates where the platform allows.
+- **Bounded latency.** Cedar evaluation is in-memory against a compiled policy set; the corpus is
+  cached and refreshed, so a decision is a map lookup plus an evaluation, not an API round-trip.
+- **TLS with the validated modules.** The webhook is a network service in the control-plane path,
+  so its serving TLS uses the same FIPS-validated crypto as every other in-cluster service
+  (a carry-forward requirement, not a new one).
+
+## The migration surface is large and must be enumerated (observed)
+
+Every grant RBAC makes implicitly becomes an explicit Cedar grant, or the cluster deadlocks the
+moment RBAC leaves. Measured on the live cluster (read-only), the surface is concrete:
+
+- **168** ServiceAccounts (each an implicit principal), **~130** ClusterRoleBinding subjects,
+  **65** namespaced RoleBindings, against **364** ClusterRoles of grant vocabulary.
+- **Cluster-admin / high-privilege holders** that must be granted explicitly first (deadlock risks):
+  `system:masters` (break-glass), the `kube-apiserver` user (`system:kubelet-api-admin`),
+  `velero/velero-server`, `longhorn-system/longhorn-support-bundle`, `kube-system/helm-traefik(-crd)`,
+  `knative-serving/controller`, and the `crossplane:masters` group — plus the platform's own
+  controllers (kubevirt, cdi, cert-manager, cnpg, mariadb-operator, metallb, nats, vault, minio) and
+  the 14 Crossplane provider SAs.
+
+This list is the true gate on removing RBAC from the chain (Phase 2 step 6): until each holder has an
+explicit, reviewed Cedar grant, enforce mode is not safe. It also feeds the NIST/CIS mapping
+([`policy-engine.md`](policy-engine.md) Phase 3), where the assurance that RBAC's minimal-privilege
+posture used to inherit from the CIS benchmark becomes a Cedar-corpus check the project must author.
+
+## Honest status
+
+- [x] **Design** — this document; the SAR→Cedar model; shadow-first; bootstrap + failure posture.
+- [x] **Implicit-principal enumeration** — observed on the live cluster (above), read-only.
+- [x] **Webhook spike** — a server that accepts a `SubjectAccessReview`, maps it to a
+      `policyengine.Request`, decides via the existing engine, and answers in shadow or enforce mode.
+      Offline, unit-tested; **not wired to any API server**.
+- [ ] **`kind: Policy` `spec.controlPlane`** — the XRD field + the drift-gate mirrors (a real schema
+      change), and a K8s loader for it. The spike reads the block if present; the field is not yet on
+      the XRD.
+- [ ] **Live shadow run** — wiring the webhook into the API server authorization config on a
+      throwaway/non-critical cluster first, then the real one, to record divergence. A consequential
+      control-plane change, gated on explicit approval.
+- [ ] **Enforce + RBAC removal** — only after divergence is understood, every implicit principal has
+      an explicit grant, and the failure posture is evidenced.

--- a/policyengine/engine.go
+++ b/policyengine/engine.go
@@ -82,10 +82,7 @@ func NewEngine(statements []Statement) (*Engine, error) {
 
 // Authorize evaluates a request: an explicit Deny wins, else an Allow permits, else default-deny.
 func (e *Engine) Authorize(r Request) Decision {
-	ctx := types.RecordMap{
-		"action":   types.String(r.Action),
-		"resource": types.String(r.Resource.Type + "::" + r.Resource.ID),
-	}
+	ctx := types.RecordMap{}
 	for k, v := range r.Context {
 		switch x := v.(type) {
 		case string:
@@ -94,6 +91,11 @@ func (e *Engine) Authorize(r Request) Decision {
 			ctx[types.String(k)] = types.Boolean(x)
 		}
 	}
+	// The reserved keys are set LAST so a caller's context can never clobber the action/resource
+	// the statements match against (a control-plane request, for instance, carries its own
+	// "resource" attribute — that must not shadow the typed resource being authorized).
+	ctx["action"] = types.String(r.Action)
+	ctx["resource"] = types.String(r.Resource.Type + "::" + r.Resource.ID)
 	req := cedar.Request{
 		Principal: types.NewEntityUID(entityType(r.Principal.Type), types.String(r.Principal.ID)),
 		Action:    types.NewEntityUID("Action", "perform"),


### PR DESCRIPTION
Phase 2 of making Cedar the platform-wide authorization authority (see `docs/policy-engine.md`).
**Design + offline spike only — NOT wired to any live API server; no posture change.**

## What's here
- **`docs/authz-webhook.md`** — the design: why the *authorization* webhook (not admission — it
  governs reads too), the SubjectAccessReview→Cedar model over `kind: Policy spec.controlPlane`,
  **shadow-first** divergence measurement, bootstrap acyclicity + a static-allow floor, the
  fail-closed/HA/TLS posture, and the **observed** implicit-principal enumeration (168 SAs, ~130
  CRB subjects, 65 RoleBindings, 364 ClusterRoles; the cluster-admin holders that gate RBAC
  removal).
- **`internal/controlplaneauthz`** — maps a SAR onto a `policyengine.Request` (verb→action,
  `resource.group`→type, `namespace/name`→id, non-resource URLs) and reuses the **same** evaluator
  under default-deny allow-list (replacement) semantics; serves last-good corpus through a blip.
- **`cmd/authz-webhook`** — the webhook server: SAR in, allow/deny/no-opinion out. Shadow (default)
  logs the Cedar decision and defers so RBAC still decides; enforce returns the decision.

## Also
Fixes a latent engine bug the spike surfaced: a caller's context could clobber the reserved
`action`/`resource` keys the statements match against. The engine now sets reserved keys last.

## Not in this PR (the honest next steps)
- `kind: Policy spec.controlPlane` XRD field + drift-gate mirrors (a real schema change).
- A **live shadow run** — wiring into an API server's authorization config — a consequential
  control-plane change, gated on explicit approval and ideally a throwaway cluster first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)