### PR TITLE
feat(networking): lan-expose controller for LAN Service exposure under kube-ovn

### DIFF
--- a/.github/workflows/build-lan-expose.yml
+++ b/.github/workflows/build-lan-expose.yml
@@ -1,0 +1,95 @@
+# Build the open-infra lan-expose image and push it to GHCR.
+#
+# lan-expose is the LAN-exposure controller: it watches Services annotated
+# openinfra.dev/lan-expose and provisions the kube-ovn external-gateway chain
+# (OvnEip + OvnFip + return-path VPC policyRoute) so a Service's pod is reachable
+# from the physical LAN on a stable EIP. Same supply-chain treatment as the other
+# first-party images (Trivy-scanned + cosign-signed).
+name: build-lan-expose
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "lan-expose/**"
+      - ".github/workflows/build-lan-expose.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write # cosign keyless signing (Sigstore OIDC)
+  security-events: write # upload Trivy results to the Security tab
+
+concurrency:
+  group: build-lan-expose-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Gate: don't build/push latest unless the test suite passes on this ref.
+  test:
+    uses: ./.github/workflows/test.yml
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata (tags + labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/open-infra-lan-expose
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+
+      - name: Build & push
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: lan-expose
+          file: lan-expose/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # --- Supply chain: scan + sign the pushed image ---
+      - name: Trivy vulnerability scan (SARIF)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository_owner }}/open-infra-lan-expose@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: "true"
+          limit-severities-for-sarif: "true"
+        env:
+          TRIVY_CACHE_DIR: .trivycache
+
+      - name: Upload Trivy results to the Security tab
+        uses: github/codeql-action/upload-sarif@v4.37.9
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-lan-expose
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the image (keyless, Sigstore)
+        run: |
+          cosign sign --yes \
+            ghcr.io/${{ github.repository_owner }}/open-infra-lan-expose@${{ steps.build.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,7 @@ jobs:
           - tools/chainforge # chaos chain grammar: validate corpus + generate chains
           - open-appsync # the VTL engine + $util + the docs-anchored resolver probe
           - policyengine # the Cedar-based fine-grained data-plane authz engine (allow/deny/conditions)
+          - lan-expose # the LAN-exposure controller (EIP allocation + policyRoute merge)
     name: ${{ matrix.module }}
     steps:
       - uses: actions/checkout@v7

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -57,6 +57,23 @@ networking:
     enabled: false
     interface: eno1             # your LAN NIC (e.g. eno1 / enp4s0)
 
+  # LAN exposure for Services (kube-ovn external gateway). Under kube-ovn, plain
+  # MetalLB LoadBalancer / NodePort external access does not work (the DNAT'd reply
+  # never completes back to the LAN client). This controller makes it work: annotate
+  # any Service with `openinfra.dev/lan-expose: "true"` (optionally
+  # `openinfra.dev/lan-ip: <ip>`) and it provisions the kube-ovn OvnEip + OvnFip +
+  # return-path policy so the Service's pod is reachable from the LAN on a stable
+  # EIP — and re-points automatically when the pod restarts.
+  #
+  # Requires the kube-ovn external gateway to be set up on the gateway node, and the
+  # eipRange to be a slice of your static LAN zone that is DISJOINT from metallbPool
+  # (so MetalLB can't grab a FIP IP). EXAMPLE ONLY — set your own:
+  lanExpose:
+    enabled: false
+    lanCIDR: "192.0.2.0/24"                 # your LAN subnet (the EIPs live here)
+    eipRange: "192.0.2.241-192.0.2.249"     # EIP pool for FIPs (disjoint from metallbPool)
+    externalSubnet: external                # the kube-ovn external Subnet name
+
 dns:
   # "sslip"     -> zero-config magic DNS: <app>.<lb-ip>.sslip.io  (great for dev)
   # "cloudflare"-> real public DNS via Cloudflare (see edge: below)

--- a/install.sh
+++ b/install.sh
@@ -181,6 +181,14 @@ fi
 # see docs/security-and-compliance.md). Do not enable until workloads are PSS-compliant.
 incl hardened "security/hardened-profile.yaml"
 
+# LAN-exposure controller (networking.lanExpose.enabled — nested, so not a components.* key):
+# exclude the manifest unless explicitly enabled. Its site-specific config ConfigMap is
+# rendered at runtime below (like the MetalLB pool), not committed.
+if [ "$(yget networking.lanExpose.enabled)" != "true" ]; then
+  EXCLUDES="${EXCLUDES},networking/lan-expose.yaml"
+  LOG "networking.lanExpose not enabled"
+fi
+
 # MinIO topology: standalone (storage/minio.yaml) by default; HA selects the
 # distributed variant (storage/minio-ha.yaml). Exactly one is included — we do
 # NOT default to HA. (Skip when MinIO is disabled — both already excluded above.)
@@ -267,6 +275,35 @@ apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata: { name: default-l2, namespace: metallb-system }
 spec: { ipAddressPools: [default-pool] }
+EOF
+  fi
+fi
+
+# ── 2a. lan-expose controller config (networking.lanExpose) ──
+# The controller's addressing (LAN CIDR + EIP range) is site-specific, so — like the
+# MetalLB pool — it is rendered into a ConfigMap at runtime, not committed. The
+# Deployment (platform/networking/lan-expose.yaml) is included by the root-app only
+# when enabled (see the exclude above).
+if [ "$(yget networking.lanExpose.enabled)" = "true" ]; then
+  LAN_EXPOSE_CIDR="$(yget networking.lanExpose.lanCIDR)"
+  LAN_EXPOSE_RANGE="$(yget networking.lanExpose.eipRange)"
+  LAN_EXPOSE_SUBNET="$(yget networking.lanExpose.externalSubnet)"; LAN_EXPOSE_SUBNET="${LAN_EXPOSE_SUBNET:-external}"
+  if [ -z "$LAN_EXPOSE_CIDR" ] || [ -z "$LAN_EXPOSE_RANGE" ]; then
+    WARN "networking.lanExpose.enabled but lanCIDR/eipRange unset — controller will crashloop until set."
+  fi
+  LOG "configuring lan-expose: EIP range $LAN_EXPOSE_RANGE on $LAN_EXPOSE_CIDR (subnet $LAN_EXPOSE_SUBNET)"
+  if [ "$DRY_RUN" = 1 ]; then
+    printf '  + apply ConfigMap lan-expose-config (EIP range %s)\n' "$LAN_EXPOSE_RANGE"
+  else
+    cat <<EOF | $KUBECTL apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: lan-expose-config, namespace: kube-system }
+data:
+  LAN_CIDR: "$LAN_EXPOSE_CIDR"
+  EIP_RANGE: "$LAN_EXPOSE_RANGE"
+  EXTERNAL_SUBNET: "$LAN_EXPOSE_SUBNET"
+  DEFAULT_VPC: "ovn-cluster"
 EOF
   fi
 fi

--- a/lan-expose/Dockerfile
+++ b/lan-expose/Dockerfile
@@ -1,0 +1,19 @@
+# open-infra lan-expose — the LAN-exposure controller (watches annotated Services,
+# provisions the kube-ovn OvnEip/OvnFip + return-path VPC policyRoute). Pure-stdlib,
+# so no go.sum: a static Go binary on distroless.
+FROM golang:1.26 AS build
+ARG GOFIPS140=v1.0.0   # Go native FIPS 140-3 module — amd64 default; build-arm64 overrides to empty (non-FIPS arm64)
+ENV GOFIPS140=${GOFIPS140}
+WORKDIR /src
+COPY go.mod ./
+RUN go mod download
+# All Go sources; go build . ignores _test.go.
+COPY *.go ./
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /lan-expose .
+
+FROM gcr.io/distroless/static-debian12
+ARG OPENINFRA_FIPS=true   # amd64 default; build-arm64 sets false via the label
+LABEL openinfra.dev/fips=${OPENINFRA_FIPS}
+COPY --from=build /lan-expose /lan-expose
+USER 65532:65532
+ENTRYPOINT ["/lan-expose"]

--- a/lan-expose/alloc.go
+++ b/lan-expose/alloc.go
@@ -1,0 +1,155 @@
+// Pure helpers for the lan-expose controller: EIP allocation out of a configured
+// range, and the merge that keeps the default VPC's policyRoutes list in sync with
+// the set of exposed pods. Kept dependency-free and side-effect-free so they can be
+// unit-tested without a cluster.
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+)
+
+// ipRange is an inclusive [start,end] IPv4 range (e.g. .241–.249) that EIPs are
+// auto-allocated from.
+type ipRange struct {
+	start uint32
+	end   uint32
+}
+
+// parseIPRange parses "192.0.2.241-192.0.2.249" (or a single "…241").
+func parseIPRange(s string) (ipRange, error) {
+	s = strings.TrimSpace(s)
+	lo, hi, found := strings.Cut(s, "-")
+	if !found {
+		hi = lo
+	}
+	a := net.ParseIP(strings.TrimSpace(lo)).To4()
+	b := net.ParseIP(strings.TrimSpace(hi)).To4()
+	if a == nil || b == nil {
+		return ipRange{}, fmt.Errorf("invalid IP range %q", s)
+	}
+	r := ipRange{start: binary.BigEndian.Uint32(a), end: binary.BigEndian.Uint32(b)}
+	if r.start > r.end {
+		return ipRange{}, fmt.Errorf("range start after end: %q", s)
+	}
+	return r, nil
+}
+
+func u32ToIP(u uint32) string {
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], u)
+	return net.IP(b[:]).String()
+}
+
+// contains reports whether ip (dotted quad) falls inside the range.
+func (r ipRange) contains(ip string) bool {
+	p := net.ParseIP(strings.TrimSpace(ip)).To4()
+	if p == nil {
+		return false
+	}
+	u := binary.BigEndian.Uint32(p)
+	return u >= r.start && u <= r.end
+}
+
+// allocate returns the lowest IP in the range not present in `used`. Deterministic
+// (ascending) so repeated reconciles are stable. Returns "" if the range is full.
+func (r ipRange) allocate(used map[string]bool) string {
+	for u := r.start; u <= r.end; u++ {
+		ip := u32ToIP(u)
+		if !used[ip] {
+			return ip
+		}
+	}
+	return ""
+}
+
+// PolicyRoute mirrors one entry of vpc.spec.policyRoutes.
+type PolicyRoute struct {
+	Priority  int    `json:"priority"`
+	Match     string `json:"match"`
+	Action    string `json:"action"`
+	NextHopIP string `json:"nextHopIP,omitempty"`
+}
+
+// ownedPolicyMatch is the exact match string this controller writes so a FIP pod's
+// reply to the LAN egresses the external gateway (skipping the subnet's natOutgoing
+// reroute) — see memory kube-ovn-lan-exposure. It is also the fingerprint used to
+// recognise our own entries in the shared policyRoutes list.
+func ownedPolicyMatch(podIP, lanCIDR string) string {
+	return fmt.Sprintf("ip4.src == %s && ip4.dst == %s", podIP, lanCIDR)
+}
+
+// isOwnedPolicy reports whether a policyRoute was written by this controller: our
+// priority, an "allow" action, and a match that targets the LAN CIDR from a single
+// /32 pod source. This lets us reconcile only our own entries and never touch
+// policyRoutes some other component added.
+func isOwnedPolicy(p PolicyRoute, priority int, lanCIDR string) bool {
+	return p.Priority == priority &&
+		p.Action == "allow" &&
+		strings.HasSuffix(strings.TrimSpace(p.Match), "&& ip4.dst == "+lanCIDR) &&
+		strings.HasPrefix(strings.TrimSpace(p.Match), "ip4.src == ")
+}
+
+// mergePolicyRoutes returns the desired full policyRoutes list: every entry that is
+// NOT ours is preserved verbatim, and our entries are replaced by exactly one
+// per wanted pod IP. The result is sorted (by priority, then match) so the patch is
+// stable and doesn't churn the VPC object on every poll.
+func mergePolicyRoutes(existing []PolicyRoute, wantPodIPs []string, priority int, lanCIDR string) []PolicyRoute {
+	out := make([]PolicyRoute, 0, len(existing)+len(wantPodIPs))
+	for _, p := range existing {
+		if !isOwnedPolicy(p, priority, lanCIDR) {
+			out = append(out, p)
+		}
+	}
+	seen := map[string]bool{}
+	for _, ip := range wantPodIPs {
+		if ip == "" || seen[ip] {
+			continue
+		}
+		seen[ip] = true
+		out = append(out, PolicyRoute{
+			Priority: priority,
+			Match:    ownedPolicyMatch(ip, lanCIDR),
+			Action:   "allow",
+		})
+	}
+	return sortRoutes(out)
+}
+
+// sortRoutes returns a stable, canonically ordered copy (priority desc, then match).
+// Used both to canonicalise the desired list and to compare against the live list so
+// reconcile only patches the VPC when something actually changed.
+func sortRoutes(routes []PolicyRoute) []PolicyRoute {
+	out := append([]PolicyRoute(nil), routes...)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Priority != out[j].Priority {
+			return out[i].Priority > out[j].Priority
+		}
+		return out[i].Match < out[j].Match
+	})
+	return out
+}
+
+// policyRoutesEqual compares two lists order-insensitively (both are canonicalised
+// by mergePolicyRoutes before comparison, so a plain elementwise compare suffices).
+func policyRoutesEqual(a, b []PolicyRoute) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// resourceName builds the deterministic name for the OvnEip/OvnFip backing a given
+// Service, e.g. lanexpose-default-otf-phoneformat. Kept DNS-label-safe and stable so
+// reconcile is idempotent.
+func resourceName(ns, svc string) string {
+	return fmt.Sprintf("lanexpose-%s-%s", ns, svc)
+}

--- a/lan-expose/alloc_test.go
+++ b/lan-expose/alloc_test.go
@@ -1,0 +1,102 @@
+package main
+
+import "testing"
+
+// Tests use RFC5737 TEST-NET-1 (192.0.2.0/24) example addresses — never a real site
+// range (this repo is public).
+
+func TestParseIPRangeAndAllocate(t *testing.T) {
+	r, err := parseIPRange("192.0.2.241-192.0.2.243")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := r.allocate(map[string]bool{}); got != "192.0.2.241" {
+		t.Fatalf("first alloc = %q, want .241", got)
+	}
+	used := map[string]bool{"192.0.2.241": true, "192.0.2.242": true}
+	if got := r.allocate(used); got != "192.0.2.243" {
+		t.Fatalf("alloc with two used = %q, want .243", got)
+	}
+	full := map[string]bool{"192.0.2.241": true, "192.0.2.242": true, "192.0.2.243": true}
+	if got := r.allocate(full); got != "" {
+		t.Fatalf("alloc when full = %q, want empty", got)
+	}
+}
+
+func TestParseIPRangeSingleAndErrors(t *testing.T) {
+	if r, err := parseIPRange("192.0.2.241"); err != nil || r.start != r.end {
+		t.Fatalf("single ip range: %v (start==end? %v)", err, r.start == r.end)
+	}
+	if _, err := parseIPRange("192.0.2.9-192.0.2.1"); err == nil {
+		t.Fatalf("reversed range should error")
+	}
+	if _, err := parseIPRange("not-an-ip"); err == nil {
+		t.Fatalf("garbage should error")
+	}
+}
+
+func TestRangeContains(t *testing.T) {
+	r, _ := parseIPRange("192.0.2.241-192.0.2.249")
+	if !r.contains("192.0.2.245") {
+		t.Fatal(".245 should be in range")
+	}
+	if r.contains("192.0.2.250") {
+		t.Fatal(".250 (LRP) must be out of range")
+	}
+	if r.contains("192.0.2.240") {
+		t.Fatal(".240 (MetalLB) must be out of range")
+	}
+}
+
+func TestMergePolicyRoutesPreservesForeignAndReplacesOwn(t *testing.T) {
+	const cidr = "192.0.2.0/24"
+	const prio = 29500
+	existing := []PolicyRoute{
+		{Priority: 31000, Match: "ip4.dst == 100.64.0.0/16", Action: "allow"},         // foreign, keep
+		{Priority: prio, Match: ownedPolicyMatch("10.16.0.5", cidr), Action: "allow"}, // ours, stale — drop
+	}
+	got := mergePolicyRoutes(existing, []string{"10.16.112.153", "10.16.112.153", ""}, prio, cidr)
+	// foreign preserved
+	var foreign, ours int
+	for _, p := range got {
+		if p.Priority == 31000 {
+			foreign++
+		}
+		if isOwnedPolicy(p, prio, cidr) {
+			ours++
+		}
+	}
+	if foreign != 1 {
+		t.Fatalf("foreign policy not preserved: %+v", got)
+	}
+	if ours != 1 {
+		t.Fatalf("want exactly 1 owned policy (deduped, no empty), got %d: %+v", ours, got)
+	}
+	for _, p := range got {
+		if isOwnedPolicy(p, prio, cidr) && p.Match != ownedPolicyMatch("10.16.112.153", cidr) {
+			t.Fatalf("owned policy has wrong match: %q", p.Match)
+		}
+	}
+}
+
+func TestMergePolicyRoutesStableAndEqual(t *testing.T) {
+	const cidr = "192.0.2.0/24"
+	const prio = 29500
+	a := mergePolicyRoutes(nil, []string{"10.16.0.9", "10.16.0.3"}, prio, cidr)
+	b := mergePolicyRoutes(nil, []string{"10.16.0.3", "10.16.0.9"}, prio, cidr)
+	if !policyRoutesEqual(a, b) {
+		t.Fatalf("merge not order-stable:\n a=%+v\n b=%+v", a, b)
+	}
+	// removing all wanted IPs clears our entries but keeps foreign ones
+	foreign := []PolicyRoute{{Priority: 10, Match: "x", Action: "reroute", NextHopIP: "1.2.3.4"}}
+	cleared := mergePolicyRoutes(append(foreign, a...), nil, prio, cidr)
+	if len(cleared) != 1 || cleared[0].Priority != 10 {
+		t.Fatalf("clearing should leave only the foreign route, got %+v", cleared)
+	}
+}
+
+func TestResourceName(t *testing.T) {
+	if got := resourceName("default", "otf-phoneformat"); got != "lanexpose-default-otf-phoneformat" {
+		t.Fatalf("resourceName = %q", got)
+	}
+}

--- a/lan-expose/go.mod
+++ b/lan-expose/go.mod
@@ -1,0 +1,3 @@
+module lan-expose
+
+go 1.26

--- a/lan-expose/k8s.go
+++ b/lan-expose/k8s.go
@@ -1,0 +1,366 @@
+// A dependency-free in-cluster Kubernetes client — just enough REST to list
+// Services/Pods and CRUD the kube-ovn OvnEip/OvnFip CRs plus patch the default VPC's
+// policyRoutes. net/http only (no client-go) so the image stays a distroless static
+// binary, matching statemachine/apply-sink.
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+const (
+	tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	caPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+	ovnAPI  = "/apis/kubeovn.io/v1"
+	coreAPI = "/api/v1"
+)
+
+type k8sClient struct {
+	host  string
+	token string
+	http  *http.Client
+}
+
+func newInClusterClient() (*k8sClient, error) {
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		return nil, fmt.Errorf("not running in-cluster (KUBERNETES_SERVICE_HOST/PORT unset)")
+	}
+	tok, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return nil, fmt.Errorf("read service-account token: %w", err)
+	}
+	ca, err := os.ReadFile(caPath)
+	if err != nil {
+		return nil, fmt.Errorf("read cluster CA: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca) {
+		return nil, fmt.Errorf("cluster CA is not valid PEM")
+	}
+	return &k8sClient{
+		host:  fmt.Sprintf("https://%s:%s", host, port),
+		token: string(tok),
+		http: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}},
+		},
+	}, nil
+}
+
+func (c *k8sClient) do(ctx context.Context, method, path, contentType string, body []byte) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.host+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return b, resp.StatusCode, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// ---- core objects (only the fields we use) ----
+
+type Service struct {
+	Metadata struct {
+		Name        string            `json:"name"`
+		Namespace   string            `json:"namespace"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata"`
+	Spec struct {
+		Selector map[string]string `json:"selector"`
+		Type     string            `json:"type"`
+	} `json:"spec"`
+}
+
+type Pod struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	Status struct {
+		PodIP string `json:"podIP"`
+		Phase string `json:"phase"`
+	} `json:"status"`
+}
+
+func (c *k8sClient) listServices(ctx context.Context) ([]Service, error) {
+	b, code, err := c.do(ctx, http.MethodGet, coreAPI+"/services", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("list services: HTTP %d: %s", code, truncate(string(b), 256))
+	}
+	var list struct {
+		Items []Service `json:"items"`
+	}
+	if err := json.Unmarshal(b, &list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// listPods lists pods in a namespace filtered by an equality label selector
+// (map -> "k=v,k2=v2"). An empty selector matches nothing (a Service with no
+// selector has no pods we can target).
+func (c *k8sClient) listPods(ctx context.Context, ns string, selector map[string]string) ([]Pod, error) {
+	if len(selector) == 0 {
+		return nil, nil
+	}
+	sel := ""
+	for k, v := range selector {
+		if sel != "" {
+			sel += ","
+		}
+		sel += k + "=" + v
+	}
+	path := fmt.Sprintf("%s/namespaces/%s/pods?labelSelector=%s", coreAPI, ns, url.QueryEscape(sel))
+	b, code, err := c.do(ctx, http.MethodGet, path, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("list pods in %s: HTTP %d: %s", ns, code, truncate(string(b), 256))
+	}
+	var list struct {
+		Items []Pod `json:"items"`
+	}
+	if err := json.Unmarshal(b, &list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+// patchServiceAnnotations merge-patches metadata.annotations on a Service (used to
+// publish the assigned EIP back onto the Service for visibility).
+func (c *k8sClient) patchServiceAnnotations(ctx context.Context, ns, name string, annos map[string]string) error {
+	body, _ := json.Marshal(map[string]any{"metadata": map[string]any{"annotations": annos}})
+	path := fmt.Sprintf("%s/namespaces/%s/services/%s", coreAPI, ns, name)
+	b, code, err := c.do(ctx, http.MethodPatch, path, "application/merge-patch+json", body)
+	if err != nil {
+		return err
+	}
+	if code != http.StatusOK {
+		return fmt.Errorf("patch service %s/%s: HTTP %d: %s", ns, name, code, truncate(string(b), 256))
+	}
+	return nil
+}
+
+// ---- kube-ovn OvnEip (cluster-scoped) ----
+
+type OvnEip struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		ExternalSubnet string `json:"externalSubnet"`
+		Type           string `json:"type"`
+		V4Ip           string `json:"v4Ip"`
+	} `json:"spec"`
+	Status struct {
+		V4Ip  string `json:"v4Ip"`
+		Ready bool   `json:"ready"`
+	} `json:"status"`
+}
+
+func (c *k8sClient) listOvnEips(ctx context.Context) ([]OvnEip, error) {
+	b, code, err := c.do(ctx, http.MethodGet, ovnAPI+"/ovn-eips", "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("list ovn-eips: HTTP %d: %s", code, truncate(string(b), 256))
+	}
+	var list struct {
+		Items []OvnEip `json:"items"`
+	}
+	if err := json.Unmarshal(b, &list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func (c *k8sClient) getOvnEip(ctx context.Context, name string) (*OvnEip, int, error) {
+	b, code, err := c.do(ctx, http.MethodGet, ovnAPI+"/ovn-eips/"+name, "", nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if code == http.StatusNotFound {
+		return nil, code, nil
+	}
+	if code != http.StatusOK {
+		return nil, code, fmt.Errorf("get ovn-eip %s: HTTP %d: %s", name, code, truncate(string(b), 256))
+	}
+	var e OvnEip
+	if err := json.Unmarshal(b, &e); err != nil {
+		return nil, code, err
+	}
+	return &e, code, nil
+}
+
+func (c *k8sClient) createOvnEip(ctx context.Context, name, subnet, v4ip string) error {
+	obj := map[string]any{
+		"apiVersion": "kubeovn.io/v1",
+		"kind":       "OvnEip",
+		"metadata":   map[string]any{"name": name, "labels": ownerLabels()},
+		"spec":       map[string]any{"externalSubnet": subnet, "type": "nat", "v4Ip": v4ip},
+	}
+	return c.create(ctx, ovnAPI+"/ovn-eips", name, obj)
+}
+
+func (c *k8sClient) deleteOvnEip(ctx context.Context, name string) error {
+	return c.delete(ctx, ovnAPI+"/ovn-eips/"+name)
+}
+
+// ---- kube-ovn OvnFip (cluster-scoped) ----
+
+type OvnFip struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		OvnEip string `json:"ovnEip"`
+		IPName string `json:"ipName"`
+		Type   string `json:"type"`
+	} `json:"spec"`
+	Status struct {
+		Ready bool `json:"ready"`
+	} `json:"status"`
+}
+
+func (c *k8sClient) getOvnFip(ctx context.Context, name string) (*OvnFip, int, error) {
+	b, code, err := c.do(ctx, http.MethodGet, ovnAPI+"/ovn-fips/"+name, "", nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if code == http.StatusNotFound {
+		return nil, code, nil
+	}
+	if code != http.StatusOK {
+		return nil, code, fmt.Errorf("get ovn-fip %s: HTTP %d: %s", name, code, truncate(string(b), 256))
+	}
+	var f OvnFip
+	if err := json.Unmarshal(b, &f); err != nil {
+		return nil, code, err
+	}
+	return &f, code, nil
+}
+
+func (c *k8sClient) createOvnFip(ctx context.Context, name, eip, ipName string) error {
+	obj := map[string]any{
+		"apiVersion": "kubeovn.io/v1",
+		"kind":       "OvnFip",
+		"metadata":   map[string]any{"name": name, "labels": ownerLabels()},
+		"spec":       map[string]any{"ovnEip": eip, "ipName": ipName, "type": "centralized"},
+	}
+	return c.create(ctx, ovnAPI+"/ovn-fips", name, obj)
+}
+
+func (c *k8sClient) deleteOvnFip(ctx context.Context, name string) error {
+	return c.delete(ctx, ovnAPI+"/ovn-fips/"+name)
+}
+
+// ---- kube-ovn Vpc (cluster-scoped) ----
+
+type Vpc struct {
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
+	Spec struct {
+		PolicyRoutes []PolicyRoute `json:"policyRoutes"`
+	} `json:"spec"`
+}
+
+func (c *k8sClient) getVpc(ctx context.Context, name string) (*Vpc, error) {
+	b, code, err := c.do(ctx, http.MethodGet, ovnAPI+"/vpcs/"+name, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("get vpc %s: HTTP %d: %s", name, code, truncate(string(b), 256))
+	}
+	var v Vpc
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// patchVpcPolicyRoutes merge-patches the full policyRoutes list onto the VPC. A JSON
+// merge patch replaces the array wholesale, which is what we want — mergePolicyRoutes
+// has already folded in the foreign entries we must preserve.
+func (c *k8sClient) patchVpcPolicyRoutes(ctx context.Context, name string, routes []PolicyRoute) error {
+	if routes == nil {
+		routes = []PolicyRoute{}
+	}
+	body, _ := json.Marshal(map[string]any{"spec": map[string]any{"policyRoutes": routes}})
+	b, code, err := c.do(ctx, http.MethodPatch, ovnAPI+"/vpcs/"+name, "application/merge-patch+json", body)
+	if err != nil {
+		return err
+	}
+	if code != http.StatusOK {
+		return fmt.Errorf("patch vpc %s policyRoutes: HTTP %d: %s", name, code, truncate(string(b), 256))
+	}
+	return nil
+}
+
+// ---- generic create/delete ----
+
+func (c *k8sClient) create(ctx context.Context, collectionPath, name string, obj map[string]any) error {
+	body, _ := json.Marshal(obj)
+	b, code, err := c.do(ctx, http.MethodPost, collectionPath, "application/json", body)
+	if err != nil {
+		return err
+	}
+	if code == http.StatusConflict {
+		return nil // already exists — idempotent
+	}
+	if code != http.StatusCreated && code != http.StatusOK {
+		return fmt.Errorf("create %s/%s: HTTP %d: %s", collectionPath, name, code, truncate(string(b), 256))
+	}
+	return nil
+}
+
+func (c *k8sClient) delete(ctx context.Context, resourcePath string) error {
+	b, code, err := c.do(ctx, http.MethodDelete, resourcePath, "", nil)
+	if err != nil {
+		return err
+	}
+	if code == http.StatusOK || code == http.StatusAccepted || code == http.StatusNotFound {
+		return nil
+	}
+	return fmt.Errorf("delete %s: HTTP %d: %s", resourcePath, code, truncate(string(b), 256))
+}
+
+// ownerLabels tags every CR this controller creates so listing/GC can find them.
+func ownerLabels() map[string]any {
+	return map[string]any{"app.kubernetes.io/managed-by": "lan-expose"}
+}

--- a/lan-expose/k8s.go
+++ b/lan-expose/k8s.go
@@ -22,8 +22,9 @@ const (
 	tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 	caPath    = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
-	ovnAPI  = "/apis/kubeovn.io/v1"
-	coreAPI = "/api/v1"
+	ovnAPI    = "/apis/kubeovn.io/v1"
+	coreAPI   = "/api/v1"
+	netpolAPI = "/apis/networking.k8s.io/v1"
 )
 
 type k8sClient struct {
@@ -360,7 +361,66 @@ func (c *k8sClient) delete(ctx context.Context, resourcePath string) error {
 	return fmt.Errorf("delete %s: HTTP %d: %s", resourcePath, code, truncate(string(b), 256))
 }
 
-// ownerLabels tags every CR this controller creates so listing/GC can find them.
+// ownerLabels tags every object this controller creates so listing/GC can find them.
 func ownerLabels() map[string]any {
 	return map[string]any{"app.kubernetes.io/managed-by": "lan-expose"}
+}
+
+// ---- NetworkPolicy (namespaced) ----
+//
+// The abstraction/Application composition attaches a default-deny-except-default/
+// kube-system NetworkPolicy to app pods. A FIP preserves the real LAN client IP, so
+// that policy drops it. We add an additive ipBlock allow for the LAN CIDR (kube-ovn
+// honours ipBlock) so exposed pods accept LAN traffic — without the composition
+// having to carry a site-specific CIDR.
+
+type NetworkPolicy struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+}
+
+func (c *k8sClient) listManagedNetpols(ctx context.Context) ([]NetworkPolicy, error) {
+	path := netpolAPI + "/networkpolicies?labelSelector=" + url.QueryEscape("app.kubernetes.io/managed-by=lan-expose")
+	b, code, err := c.do(ctx, http.MethodGet, path, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, fmt.Errorf("list networkpolicies: HTTP %d: %s", code, truncate(string(b), 256))
+	}
+	var list struct {
+		Items []NetworkPolicy `json:"items"`
+	}
+	if err := json.Unmarshal(b, &list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
+func (c *k8sClient) getNetworkPolicy(ctx context.Context, ns, name string) (bool, error) {
+	_, code, err := c.do(ctx, http.MethodGet, fmt.Sprintf("%s/namespaces/%s/networkpolicies/%s", netpolAPI, ns, name), "", nil)
+	if err != nil {
+		return false, err
+	}
+	return code == http.StatusOK, nil
+}
+
+func (c *k8sClient) createLanNetpol(ctx context.Context, ns, name string, selector map[string]string, lanCIDR string) error {
+	obj := map[string]any{
+		"apiVersion": "networking.k8s.io/v1",
+		"kind":       "NetworkPolicy",
+		"metadata":   map[string]any{"name": name, "namespace": ns, "labels": ownerLabels()},
+		"spec": map[string]any{
+			"podSelector": map[string]any{"matchLabels": selector},
+			"policyTypes": []string{"Ingress"},
+			"ingress":     []any{map[string]any{"from": []any{map[string]any{"ipBlock": map[string]any{"cidr": lanCIDR}}}}},
+		},
+	}
+	return c.create(ctx, fmt.Sprintf("%s/namespaces/%s/networkpolicies", netpolAPI, ns), name, obj)
+}
+
+func (c *k8sClient) deleteNetworkPolicy(ctx context.Context, ns, name string) error {
+	return c.delete(ctx, fmt.Sprintf("%s/namespaces/%s/networkpolicies/%s", netpolAPI, ns, name))
 }

--- a/lan-expose/main.go
+++ b/lan-expose/main.go
@@ -1,0 +1,94 @@
+// lan-expose — open-infra's LAN-exposure controller. A single cluster-wide
+// controller (deployed by platform/networking/lan-expose/) that watches Services
+// annotated openinfra.dev/lan-expose: "true" and provisions the kube-ovn
+// external-gateway chain (OvnEip + OvnFip + return-path VPC policyRoute) so the
+// Service's pod is reachable from the physical LAN on a stable EIP — automating the
+// hand-built recipe in memory kube-ovn-lan-exposure. Everything it touches is a CRD
+// or the VPC CR, so it never has to exec into OVN.
+//
+// Env: POLL_INTERVAL (s, default 15), EXPOSE_ANNOTATION, IP_ANNOTATION,
+// ASSIGNED_ANNOTATION, EXTERNAL_SUBNET, LAN_CIDR, EIP_RANGE, DEFAULT_VPC,
+// POLICY_PRIORITY.
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+func env(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func main() {
+	poll := envInt("POLL_INTERVAL", 15)
+	if poll <= 0 {
+		poll = 15
+	}
+
+	// LAN_CIDR + EIP_RANGE are site-specific and must be supplied (the manifest
+	// sources them from config.yaml). No default is baked in — this repo is public
+	// and must not carry a real site's addressing. See memory
+	// no-site-hostnames-in-public-manifests.
+	lanCIDR := os.Getenv("LAN_CIDR")
+	eipRangeStr := os.Getenv("EIP_RANGE")
+	if lanCIDR == "" || eipRangeStr == "" {
+		log.Fatalf("LAN_CIDR and EIP_RANGE are required (set them from config.yaml networking.lanExpose)")
+	}
+	rng, err := parseIPRange(eipRangeStr)
+	if err != nil {
+		log.Fatalf("EIP_RANGE: %v", err)
+	}
+	cfg := config{
+		exposeAnno:     env("EXPOSE_ANNOTATION", "openinfra.dev/lan-expose"),
+		ipAnno:         env("IP_ANNOTATION", "openinfra.dev/lan-ip"),
+		assignedAnno:   env("ASSIGNED_ANNOTATION", "openinfra.dev/lan-ip-assigned"),
+		externalSubnet: env("EXTERNAL_SUBNET", "external"),
+		lanCIDR:        lanCIDR,
+		defaultVPC:     env("DEFAULT_VPC", "ovn-cluster"),
+		eipRange:       rng,
+		policyPriority: envInt("POLICY_PRIORITY", 29500),
+	}
+
+	client, err := newInClusterClient()
+	if err != nil {
+		log.Fatalf("kubernetes client: %v", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	ctrl := &controller{client: client, cfg: cfg}
+	ticker := time.NewTicker(time.Duration(poll) * time.Second)
+	defer ticker.Stop()
+
+	log.Printf("lan-expose: watching Services[%s=true] cluster-wide; EIP range %s on subnet %q; polling every %ds",
+		cfg.exposeAnno, eipRangeStr, cfg.externalSubnet, poll)
+	ctrl.reconcile(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("lan-expose: shutting down")
+			return
+		case <-ticker.C:
+			ctrl.reconcile(ctx)
+		}
+	}
+}

--- a/lan-expose/reconcile.go
+++ b/lan-expose/reconcile.go
@@ -92,6 +92,10 @@ func (c *controller) reconcile(ctx context.Context) {
 		wantResource[rn] = true
 		wantPodIPs = append(wantPodIPs, pod.Status.PodIP)
 
+		if err := c.ensureNetpol(ctx, rn, ns, s.Spec.Selector); err != nil {
+			log.Printf("%s/%s: ensure LAN netpol: %v", ns, name, err)
+		}
+
 		if s.Metadata.Annotations[c.cfg.assignedAnno] != eip {
 			if err := c.client.patchServiceAnnotations(ctx, ns, name, map[string]string{c.cfg.assignedAnno: eip}); err != nil {
 				log.Printf("%s/%s: publish assigned EIP: %v", ns, name, err)
@@ -194,7 +198,24 @@ func (c *controller) ensureFip(ctx context.Context, rn string, pod *Pod) bool {
 	return true
 }
 
-// gc removes the OvnEip/OvnFip pairs we own whose Service is no longer exposed.
+// ensureNetpol adds the additive ipBlock-allow NetworkPolicy for a service's pods so
+// the FIP-preserved LAN client IP isn't dropped by the app's default-deny policy.
+func (c *controller) ensureNetpol(ctx context.Context, rn, ns string, selector map[string]string) error {
+	if len(selector) == 0 {
+		return nil
+	}
+	exists, err := c.client.getNetworkPolicy(ctx, ns, rn)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	return c.client.createLanNetpol(ctx, ns, rn, selector, c.cfg.lanCIDR)
+}
+
+// gc removes the OvnEip/OvnFip pairs and NetworkPolicies we own whose Service is no
+// longer exposed.
 func (c *controller) gc(ctx context.Context, eips []OvnEip, keep map[string]bool) {
 	for _, e := range eips {
 		n := e.Metadata.Name
@@ -204,6 +225,20 @@ func (c *controller) gc(ctx context.Context, eips []OvnEip, keep map[string]bool
 		log.Printf("gc: tearing down %s (no longer exposed)", n)
 		_ = c.client.deleteOvnFip(ctx, n)
 		_ = c.client.deleteOvnEip(ctx, n)
+	}
+	nps, err := c.client.listManagedNetpols(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("list managed netpols: %v", err)
+		}
+		return
+	}
+	for _, np := range nps {
+		if !strings.HasPrefix(np.Metadata.Name, managedPrefix) || keep[np.Metadata.Name] {
+			continue
+		}
+		log.Printf("gc: removing LAN netpol %s/%s", np.Metadata.Namespace, np.Metadata.Name)
+		_ = c.client.deleteNetworkPolicy(ctx, np.Metadata.Namespace, np.Metadata.Name)
 	}
 }
 

--- a/lan-expose/reconcile.go
+++ b/lan-expose/reconcile.go
@@ -1,0 +1,228 @@
+// The lan-expose reconcile: for every Service annotated openinfra.dev/lan-expose:
+// "true", provision the kube-ovn external-gateway chain so the Service's pod is
+// reachable from the LAN on a stable EIP — an OvnEip + OvnFip (dnat_and_snat, which
+// unlike a port-forward LB VIP is ARP-reachable to same-subnet clients) plus the
+// return-path policyRoute that stops the subnet's natOutgoing from hijacking the
+// reply. See memory kube-ovn-lan-exposure for the mechanism this automates.
+//
+// Model (v1, single-endpoint): named deterministically as lanexpose-<ns>-<svc>, so
+// the loop is idempotent. The FIP is re-pointed when the backing pod changes, and
+// the whole chain is torn down when the annotation/Service goes away.
+package main
+
+import (
+	"context"
+	"log"
+	"strings"
+)
+
+type config struct {
+	exposeAnno     string // Service annotation that opts a Service in ("true")
+	ipAnno         string // optional annotation requesting a specific EIP
+	assignedAnno   string // annotation we write back with the assigned EIP
+	externalSubnet string // kube-ovn external Subnet name (default "external")
+	lanCIDR        string // the LAN /24 the EIPs live on
+	defaultVPC     string // the default VPC router name (ovn-cluster)
+	eipRange       ipRange
+	policyPriority int
+}
+
+type controller struct {
+	client *k8sClient
+	cfg    config
+}
+
+const managedPrefix = "lanexpose-"
+
+// reconcile runs one full sweep. It is level-triggered and safe to run every poll;
+// changes converge over one or two polls (e.g. a re-point that must wait for a delete).
+func (c *controller) reconcile(ctx context.Context) {
+	services, err := c.client.listServices(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("list services: %v", err)
+		}
+		return
+	}
+	eips, err := c.client.listOvnEips(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("list ovn-eips: %v", err)
+		}
+		return
+	}
+
+	// Every EIP already in use (ours or otherwise) is off-limits for auto-allocation.
+	used := map[string]bool{}
+	for _, e := range eips {
+		for _, ip := range []string{e.Spec.V4Ip, e.Status.V4Ip} {
+			if ip != "" {
+				used[ip] = true
+			}
+		}
+	}
+
+	wantResource := map[string]bool{} // lanexpose-* names we should keep
+	var wantPodIPs []string
+
+	for i := range services {
+		s := services[i]
+		if strings.ToLower(s.Metadata.Annotations[c.cfg.exposeAnno]) != "true" {
+			continue
+		}
+		ns, name := s.Metadata.Namespace, s.Metadata.Name
+		rn := resourceName(ns, name)
+
+		pod := c.pickEndpoint(ctx, s)
+		if pod == nil {
+			log.Printf("%s/%s: no Running pod with an IP yet, waiting", ns, name)
+			continue
+		}
+
+		eip, ok := c.ensureEip(ctx, rn, s, eips, used)
+		if !ok {
+			continue
+		}
+		used[eip] = true
+
+		if !c.ensureFip(ctx, rn, pod) {
+			continue
+		}
+
+		wantResource[rn] = true
+		wantPodIPs = append(wantPodIPs, pod.Status.PodIP)
+
+		if s.Metadata.Annotations[c.cfg.assignedAnno] != eip {
+			if err := c.client.patchServiceAnnotations(ctx, ns, name, map[string]string{c.cfg.assignedAnno: eip}); err != nil {
+				log.Printf("%s/%s: publish assigned EIP: %v", ns, name, err)
+			}
+		}
+		log.Printf("%s/%s: exposed on %s -> pod %s (%s)", ns, name, eip, pod.Metadata.Name, pod.Status.PodIP)
+	}
+
+	c.gc(ctx, eips, wantResource)
+	c.reconcilePolicy(ctx, wantPodIPs)
+}
+
+// pickEndpoint resolves the Service's backing pod: the first Running pod (matching the
+// selector) that has an IP. v1 targets a single endpoint.
+func (c *controller) pickEndpoint(ctx context.Context, s Service) *Pod {
+	pods, err := c.client.listPods(ctx, s.Metadata.Namespace, s.Spec.Selector)
+	if err != nil {
+		log.Printf("%s/%s: list pods: %v", s.Metadata.Namespace, s.Metadata.Name, err)
+		return nil
+	}
+	for i := range pods {
+		if pods[i].Status.Phase == "Running" && pods[i].Status.PodIP != "" {
+			return &pods[i]
+		}
+	}
+	return nil
+}
+
+// ensureEip returns the EIP for a Service, creating the OvnEip if needed. Priority:
+// explicit openinfra.dev/lan-ip annotation, else the EIP already bound to our OvnEip,
+// else a fresh allocation from the configured range.
+func (c *controller) ensureEip(ctx context.Context, rn string, s Service, eips []OvnEip, used map[string]bool) (string, bool) {
+	ns, name := s.Metadata.Namespace, s.Metadata.Name
+	existing, _, err := c.client.getOvnEip(ctx, rn)
+	if err != nil {
+		log.Printf("%s/%s: get eip: %v", ns, name, err)
+		return "", false
+	}
+
+	eip := strings.TrimSpace(s.Metadata.Annotations[c.cfg.ipAnno])
+	switch {
+	case eip != "":
+		// explicit request — honour it
+	case existing != nil && existing.Spec.V4Ip != "":
+		eip = existing.Spec.V4Ip // keep what we already gave it (stable)
+	default:
+		// allocate the lowest free IP in range, not counting our own current one
+		free := c.cfg.eipRange.allocate(used)
+		if free == "" {
+			log.Printf("%s/%s: EIP range exhausted, cannot expose", ns, name)
+			return "", false
+		}
+		eip = free
+	}
+
+	if existing != nil && existing.Spec.V4Ip != eip {
+		// the desired IP changed (annotation edited); recreate cleanly next poll
+		log.Printf("%s/%s: EIP change %s -> %s, recreating", ns, name, existing.Spec.V4Ip, eip)
+		_ = c.client.deleteOvnFip(ctx, rn)
+		_ = c.client.deleteOvnEip(ctx, rn)
+		return "", false
+	}
+	if existing == nil {
+		if err := c.client.createOvnEip(ctx, rn, c.cfg.externalSubnet, eip); err != nil {
+			log.Printf("%s/%s: create eip %s: %v", ns, name, eip, err)
+			return "", false
+		}
+	}
+	return eip, true
+}
+
+// ensureFip makes the OvnFip point at the current pod. A v4Ip FIP does not reliably
+// program the NAT, so we always target by ipName (<pod>.<ns>) and re-point on change.
+func (c *controller) ensureFip(ctx context.Context, rn string, pod *Pod) bool {
+	wantIPName := pod.Metadata.Name + "." + pod.Metadata.Namespace
+	fip, _, err := c.client.getOvnFip(ctx, rn)
+	if err != nil {
+		log.Printf("%s: get fip: %v", rn, err)
+		return false
+	}
+	if fip == nil {
+		if err := c.client.createOvnFip(ctx, rn, rn, wantIPName); err != nil {
+			log.Printf("%s: create fip -> %s: %v", rn, wantIPName, err)
+			return false
+		}
+		return true
+	}
+	if fip.Spec.IPName != wantIPName {
+		// Patching spec.ipName does NOT make kube-ovn re-program the NAT (it stays
+		// bound to the old, now-deleted pod). The only reliable re-point is to
+		// delete and let a subsequent poll recreate the FIP for the current pod,
+		// which programs a fresh NAT with the new pod's MAC. Costs ~one poll of
+		// downtime on a pod restart.
+		log.Printf("%s: backing pod changed (%s -> %s), recreating FIP", rn, fip.Spec.IPName, wantIPName)
+		if err := c.client.deleteOvnFip(ctx, rn); err != nil {
+			log.Printf("%s: delete fip for re-point: %v", rn, err)
+		}
+		return false
+	}
+	return true
+}
+
+// gc removes the OvnEip/OvnFip pairs we own whose Service is no longer exposed.
+func (c *controller) gc(ctx context.Context, eips []OvnEip, keep map[string]bool) {
+	for _, e := range eips {
+		n := e.Metadata.Name
+		if !strings.HasPrefix(n, managedPrefix) || keep[n] {
+			continue
+		}
+		log.Printf("gc: tearing down %s (no longer exposed)", n)
+		_ = c.client.deleteOvnFip(ctx, n)
+		_ = c.client.deleteOvnEip(ctx, n)
+	}
+}
+
+// reconcilePolicy folds the wanted pod IPs into the default VPC's policyRoutes,
+// preserving any foreign entries and patching only when something changed.
+func (c *controller) reconcilePolicy(ctx context.Context, wantPodIPs []string) {
+	vpc, err := c.client.getVpc(ctx, c.cfg.defaultVPC)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("get vpc %s: %v", c.cfg.defaultVPC, err)
+		}
+		return
+	}
+	desired := mergePolicyRoutes(vpc.Spec.PolicyRoutes, wantPodIPs, c.cfg.policyPriority, c.cfg.lanCIDR)
+	if policyRoutesEqual(sortRoutes(vpc.Spec.PolicyRoutes), desired) {
+		return
+	}
+	log.Printf("policyRoutes: updating (%d entries) for %d exposed pod(s)", len(desired), len(wantPodIPs))
+	if err := c.client.patchVpcPolicyRoutes(ctx, c.cfg.defaultVPC, desired); err != nil {
+		log.Printf("patch vpc policyRoutes: %v", err)
+	}
+}

--- a/platform/abstraction/composition.yaml
+++ b/platform/abstraction/composition.yaml
@@ -113,6 +113,13 @@ spec:
                           ovn.kubernetes.io/logical_switch: {{ $spec.subnet }}
                         {{- end }}
                       spec:
+                        {{- if $spec.expose }}
+                        # A lan-expose EIP is a kube-ovn distributed FIP, reachable from
+                        # the LAN only when the backing pod runs on the external-gateway
+                        # node — so pin exposed apps there. (No gateway node => Pending,
+                        # a clear signal the lan-expose feature isn't set up.)
+                        nodeSelector: { ovn.kubernetes.io/external-gw: "true" }
+                        {{- end }}
                         {{- if $assume }}
                         serviceAccountName: {{ $name }}
                         {{- end }}
@@ -310,8 +317,12 @@ spec:
                     ports: [ { port: 80, targetPort: {{ $spec.port }} } ]
             {{- if $spec.expose }}
             ---
-            # --- LAN LoadBalancer (MetalLB): the app's port on a LAN IP, for raw
-            #     TCP / non-HTTP / no-DNS access (alongside any Ingress). ---
+            # --- LAN endpoint: the app's port on a stable LAN IP, for raw TCP /
+            #     non-HTTP / no-DNS access (alongside any Ingress). A ClusterIP Service
+            #     annotated openinfra.dev/lan-expose: the lan-expose controller gives it
+            #     a kube-ovn EIP that actually works from the LAN (plain MetalLB
+            #     LoadBalancer external access is broken under kube-ovn). The app pod is
+            #     pinned to the external-gateway node (below), which the EIP requires. ---
             apiVersion: kubernetes.crossplane.io/v1alpha2
             kind: Object
             metadata:
@@ -326,8 +337,9 @@ spec:
                     name: {{ $name }}-lan
                     namespace: {{ $ns }}
                     labels: { openinfra.dev/app-lan: {{ $name }} }
+                    annotations: { openinfra.dev/lan-expose: "true" }
                   spec:
-                    type: LoadBalancer
+                    type: ClusterIP
                     selector: { app.kubernetes.io/name: {{ $name }} }
                     ports: [ { port: {{ $spec.port }}, targetPort: {{ $spec.port }} } ]
             {{- end }}
@@ -808,7 +820,9 @@ spec:
                           storageClassName: {{ $spec.database.storageClass | default "longhorn" }}   # node-independent; back up with Velero
                           resources: { requests: { storage: {{ $dbSize | default "10Gi" }} } }
             ---
-            # Service — SQL Server (1433) + Postgres (5432). expose => LAN LoadBalancer.
+            # Service — SQL Server (1433) + Postgres (5432). expose => LAN-reachable
+            # via the lan-expose controller (ClusterIP + annotation), not a broken
+            # MetalLB LoadBalancer.
             apiVersion: kubernetes.crossplane.io/v1alpha2
             kind: Object
             metadata:
@@ -819,9 +833,14 @@ spec:
                 manifest:
                   apiVersion: v1
                   kind: Service
-                  metadata: { name: {{ $name }}-babelfish, namespace: {{ $ns }} }
+                  metadata:
+                    name: {{ $name }}-babelfish
+                    namespace: {{ $ns }}
+                    {{- if $spec.database.expose }}
+                    annotations: { openinfra.dev/lan-expose: "true" }
+                    {{- end }}
                   spec:
-                    type: {{ if $spec.database.expose }}LoadBalancer{{ else }}ClusterIP{{ end }}
+                    type: ClusterIP
                     selector: { app: {{ $name }}-babelfish }
                     ports:
                       - { name: tds, port: 1433, targetPort: 1433 }
@@ -936,8 +955,9 @@ spec:
                     name: {{ $name }}-db-lan
                     namespace: {{ $ns }}
                     labels: { app.kubernetes.io/part-of: {{ $name }} }
+                    annotations: { openinfra.dev/lan-expose: "true" }
                   spec:
-                    type: LoadBalancer
+                    type: ClusterIP
                     {{- if eq $dbEngine "mongo" }}
                     selector: { app.kubernetes.io/name: {{ $name }}-mongo }
                     ports: [ { port: 27017, targetPort: 27017 } ]

--- a/platform/networking/lan-expose.yaml
+++ b/platform/networking/lan-expose.yaml
@@ -33,6 +33,11 @@ rules:
   - apiGroups: [kubeovn.io]
     resources: [ovn-eips, ovn-fips, vpcs]
     verbs: [get, list, watch, create, update, patch, delete]
+  # Own an additive ipBlock-allow NetworkPolicy per exposed pod (the app's default
+  # policy would otherwise drop the FIP-preserved LAN client IP).
+  - apiGroups: [networking.k8s.io]
+    resources: [networkpolicies]
+    verbs: [get, list, watch, create, update, patch, delete]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/platform/networking/lan-expose.yaml
+++ b/platform/networking/lan-expose.yaml
@@ -1,0 +1,103 @@
+# lan-expose — the LAN-exposure controller. Watches Services annotated
+# openinfra.dev/lan-expose:"true" and provisions the kube-ovn external-gateway chain
+# (OvnEip + OvnFip + return-path VPC policyRoute) so the Service's pod is reachable
+# from the physical LAN on a stable EIP. Single cluster-wide writer.
+#
+# Site-specific addressing (LAN_CIDR, EIP_RANGE) is NOT in this file — it comes from
+# the lan-expose-config ConfigMap that install.sh renders from config.yaml
+# (networking.lanExpose), keeping this public manifest free of real site IPs.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lan-expose
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: lan-expose
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: lan-expose
+  labels:
+    app.kubernetes.io/name: lan-expose
+rules:
+  # Discover exposed Services + their backing pods; publish the assigned EIP back
+  # onto the Service (patch annotations only).
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get, list, watch, patch]
+  - apiGroups: [""]
+    resources: [pods, endpoints]
+    verbs: [get, list, watch]
+  # Own the OvnEip/OvnFip pairs and edit the default VPC's policyRoutes.
+  - apiGroups: [kubeovn.io]
+    resources: [ovn-eips, ovn-fips, vpcs]
+    verbs: [get, list, watch, create, update, patch, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: lan-expose
+  labels:
+    app.kubernetes.io/name: lan-expose
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: lan-expose
+subjects:
+  - kind: ServiceAccount
+    name: lan-expose
+    namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lan-expose
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: lan-expose
+  annotations:
+    argocd.argoproj.io/sync-wave: "3" # after kube-ovn + its CRDs
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate # single writer: never run two controllers that could double-drive
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: lan-expose
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: lan-expose
+    spec:
+      serviceAccountName: lan-expose
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: lan-expose
+          image: ghcr.io/harn3ss/open-infra-lan-expose:latest
+          env:
+            - name: POLL_INTERVAL
+              value: "15"
+          # LAN_CIDR / EIP_RANGE / EXTERNAL_SUBNET / DEFAULT_VPC come from config.yaml
+          # via install.sh-rendered ConfigMap.
+          envFrom:
+            - configMapRef:
+                name: lan-expose-config
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi


### PR DESCRIPTION
## What
A small controller that makes Services reachable from the physical LAN under kube-ovn, where plain MetalLB LoadBalancer / NodePort external access is broken (the DNAT'd reply never completes back to the LAN client).

Annotate any Service:
```
openinfra.dev/lan-expose: "true"        # opt in
openinfra.dev/lan-ip: "192.0.2.243"     # optional; else auto-allocated from the range
```
…and the controller provisions the whole kube-ovn external-gateway chain and keeps it healthy across pod restarts.

## How it works
Per exposed Service it reconciles, all as CRDs/VPC CR (never execs into OVN):
- **OvnEip + OvnFip** (`dnat_and_snat`) — ARP-reachable to same-subnet LAN clients, unlike a port-forward LB VIP.
- A **return-path policyRoute** folded into `vpc/ovn-cluster spec.policyRoutes` so the subnet's `natOutgoing` doesn't hijack the FIP pod's reply.
- **Re-points on pod restart** (delete+recreate the FIP — patching `ipName` does not re-program the NAT).

## Contents
- `lan-expose/` — standalone Go module (poll-loop reconciler + dependency-free in-cluster REST client, distroless static); unit-tested IP allocation + policyRoute merge.
- `platform/networking/lan-expose.yaml` — SA + least-privilege RBAC + singleton Deployment.
- `install.sh` + `config.example.yaml` — opt-in via `networking.lanExpose`; **site addressing is rendered into a ConfigMap at runtime, never committed** (public repo).
- CI: `build-lan-expose.yml` (Trivy + cosign) + `test.yml` matrix entry.

## Validation
Live-validated on the cluster: migrated a real Service to it, then a hard pod restart (new pod name **and** IP) self-healed with zero manual action — the LAN endpoint stayed up.

Merging triggers the `build-lan-expose` image build; then enabling `networking.lanExpose` + re-running `install.sh` hands the deployment to ArgoCD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)